### PR TITLE
Add .gitattributes to enforce line endings for scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# dotnet-install scripts must have LF line endings to support macOS and Linux
+*.sh text eol=lf
+*.ps1 text eol=lf


### PR DESCRIPTION
Fixes #39 

Added a .gitattributes file so that any .ps1 or .sh file pushed or checked out will have LF line endings.