### PR TITLE
Add .gitattributes to enforce correct line endings for scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-# dotnet-install scripts must have LF line endings to support macOS and Linux
+# bash script must have LF line endings to support macOS and Linux
 *.sh text eol=lf
-*.ps1 text eol=lf
+# powershell script must have CRLF line endings for signature validation to work
+*.ps1 text eol=crlf


### PR DESCRIPTION
Relates to #40 
.ps1 script signature cannot be validated if the signature block doesn't have CRLF line endings. This pr ensures that .ps1 always has CRLF line endings.