### PR TITLE
Allow Bypass list to be passed into the proxy

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -69,6 +69,8 @@
 .PARAMETER ProxyUseDefaultCredentials
     Default: false
     Use default credentials, when using proxy address.
+.PARAMETER ProxyBypassList
+    If set with ProxyAddress, will provide the list of comma separated urls that will bypass the proxy
 .PARAMETER SkipNonVersionedFiles
     Default: false
     Skips installing non-versioned files if they already exist, such as dotnet.exe.
@@ -96,6 +98,7 @@ param(
    [string]$FeedCredential,
    [string]$ProxyAddress,
    [switch]$ProxyUseDefaultCredentials,
+   [string]$ProxyBypassList="",
    [switch]$SkipNonVersionedFiles,
    [switch]$NoCdn
 )
@@ -253,7 +256,11 @@ function GetHTTPResponse([Uri] $Uri)
 
             if($ProxyAddress) {
                 $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
-                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress;UseDefaultCredentials=$ProxyUseDefaultCredentials}
+                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{
+                    Address=$ProxyAddress;
+                    UseDefaultCredentials=$ProxyUseDefaultCredentials;
+                    BypassList = $ProxyBypassList.Split(",")
+                }
                 $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
             }
             else {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -98,7 +98,7 @@ param(
    [string]$FeedCredential,
    [string]$ProxyAddress,
    [switch]$ProxyUseDefaultCredentials,
-   [string]$ProxyBypassList="",
+   [string[]]$ProxyBypassList,
    [switch]$SkipNonVersionedFiles,
    [switch]$NoCdn
 )
@@ -259,7 +259,7 @@ function GetHTTPResponse([Uri] $Uri)
                 $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{
                     Address=$ProxyAddress;
                     UseDefaultCredentials=$ProxyUseDefaultCredentials;
-                    BypassList = $ProxyBypassList.Split(",")
+                    BypassList = $ProxyBypassList;
                 }
                 $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
             }


### PR DESCRIPTION
Required for actions/setup-dotnet#71. Agents can set proxy settings for their runs which include addresses which should not go through the proxy. This script doesn't allow that value to be specified for windows. In the shell script this is handled by wget and curl both honoring the environment variables `https_proxy` and `no_proxy`.