### PR TITLE
ProxyBypassList must not be null

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -98,7 +98,7 @@ param(
    [string]$FeedCredential,
    [string]$ProxyAddress,
    [switch]$ProxyUseDefaultCredentials,
-   [string[]]$ProxyBypassList,
+   [string[]]$ProxyBypassList=@(),
    [switch]$SkipNonVersionedFiles,
    [switch]$NoCdn
 )


### PR DESCRIPTION
ProxyBypassList must not be null.
Otherwise setting it on the proxy object throws an exception.