### PR TITLE
Get default proxy bypass list

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -245,6 +245,7 @@ function GetHTTPResponse([Uri] $Uri)
                     if($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
                         $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
                         $ProxyUseDefaultCredentials = $true
+                        $ProxyBypassList = ([System.Net.WebProxy]$DefaultProxy).BypassList
                     }
                 } catch {
                     # Eat the exception and move forward as the above code is an attempt


### PR DESCRIPTION
* https://github.com/dotnet/install-scripts/blob/ca03088d777fb308610b1c69999b9ecb9697d53a/src/dotnet-install.ps1#L262 needs a `ProxyBypassList`, but it didn't set after got the default proxy setting
* Relate with #67 