### PR TITLE
Removed arcade validation build step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,16 +199,6 @@ stages:
         command: test
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
-  - stage: ValidateSdk
-    displayName: Validate Arcade SDK
-    dependsOn: build
-    jobs:
-    - template: /eng/validate-sdk.yml
-      parameters:
-        buildArgs: -configuration $(_BuildConfig) 
-          -prepareMachine
-          $(_InternalBuildArgs)
-          /p:Test=false
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       enableSigningValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,6 @@ stages:
       enableSourceLinkValidation: false
       publishDependsOn:
       - Validate
-      - ValidateSdk
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
         enable: true


### PR DESCRIPTION
Internal builds are failing because arcade validation step encounters an error about installed sdk version.

Initial discussion in "Arcade - First Responders" Teams channel signals that this step is not needed in this repo. Other arcade-based repos under dotnet are also not running this step.

Therefore, this PR removes that validation step from our build pipeline.