### PR TITLE
Fix SDK version parsing from global.json in install script on macOS

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -468,7 +468,6 @@ parse_jsonfile_for_version() {
     sdk_list=$(echo $sdk_section | awk -F"[{}]" '{print $2}')
     sdk_list=${sdk_list//[\" ]/}
     sdk_list=${sdk_list//,/$'\n'}
-    sdk_list="$(echo -e "${sdk_list}" | tr -d '[[:space:]]')"
 
     local version_info=""
     while read -r line; do

--- a/tests/Install-Scripts.Test/Assets/InstallationScriptTestsWithMultipleSdkFields.json
+++ b/tests/Install-Scripts.Test/Assets/InstallationScriptTestsWithMultipleSdkFields.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "1.0.0-beta.19463.3",
+        "allowPrerelease": true,
+        "rollForward": "major"
+    }
+}

--- a/tests/Install-Scripts.Test/Assets/InstallationScriptTestsWithVersionFieldInTheMiddle.json
+++ b/tests/Install-Scripts.Test/Assets/InstallationScriptTestsWithVersionFieldInTheMiddle.json
@@ -1,0 +1,5 @@
+{
+    "sdk": {
+        "allowPrerelease": true,  "version" : "1.0.0-beta.19463.3"  , "rollForward": "major"
+    }
+}

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallTheSdkFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallTheSdkFromAScript.cs
@@ -13,11 +13,14 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class GivenThatIWantToInstallTheSdkFromAScript
     {
-        [Fact]
-        public void WhenJsonFileIsPassedToInstallScripts()
+        [Theory]
+        [InlineData("InstallationScriptTests.json")]
+        [InlineData("InstallationScriptTestsWithMultipleSdkFields.json")]
+        [InlineData("InstallationScriptTestsWithVersionFieldInTheMiddle.json")]
+        public void WhenJsonFileIsPassedToInstallScripts(string filename)
         {
             var installationScriptTestsJsonFile = Path.Combine(Environment.CurrentDirectory,
-                "Assets", "InstallationScriptTests.json");
+                "Assets", filename);
 
             var args = new List<string> { "-dryrun", "-jsonfile", installationScriptTestsJsonFile };
 
@@ -30,7 +33,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().NotHaveStdOutContaining("dryrun");
             commandResult.Should().NotHaveStdOutContaining("jsonfile");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
-            commandResult.Should().HaveStdOutContaining("1.0.0-beta.19463.3");
+            commandResult.Should().HaveStdOutContaining("\"1.0.0-beta.19463.3\"");
         }
 
         [Theory]

--- a/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
+++ b/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
@@ -9,10 +9,18 @@
 
   <ItemGroup>
     <None Remove="Assets\InstallationScriptTests.json" />
+    <None Remove="Assets\InstallationScriptTestsWithMultipleSdkFields.json" />
+    <None Remove="Assets\InstallationScriptTestsWithVersionFieldInTheMiddle.json" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\InstallationScriptTests.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\InstallationScriptTestsWithMultipleSdkFields.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\InstallationScriptTestsWithVersionFieldInTheMiddle.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
For #7 

Running install script `scripts/obtain/dotnet-install.sh` with `jsonfile` argument works on macOS only when `sdk` section has a single property `version`. When `sdk` section has multiple properties, for example,
```json
"sdk": {
    "version":  "5.0.100-preview.6.20310.4",
    "allowPrerelease": true,
    "rollForward": "major"
  }
```
a version is detected as `5.0.100-preview.6.20310.4allowPrerelease:truerollForward:major`.
Also, in a case when `version` is not the first property in `sdk` a version can not be detected returning an error ``dotnet_install: Error: Unable to find the SDK:version node in `global.json` ``.

The problem seems to be in line:
```
sdk_list="$(echo -e "${sdk_list}" | tr -d '[[:space:]]')"
```
On macOS, echo does not have a `-e` argument, and all lines of key-value pairs in `sdk_list` are merged into a single line. So, removing it seems to fix it. I don't have a Linux to test the changes, but I hope CI will catch any issues on Linux. 