### PR TITLE
Removing dependencies check, adding a link to documentation page

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -773,5 +773,7 @@ Remove-Item $ZipPath
 
 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
 
+Say "Please note that the script does not resolve dependencies during installation."
+Say "To check the list of dependencies, go to https://docs.microsoft.com/en-us/dotnet/core/install/windows#dependencies"
 Say "Installation finished"
 exit 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -241,42 +241,6 @@ check_min_reqs() {
     return 0
 }
 
-check_pre_reqs() {
-    eval $invocation
-
-    if [ "${DOTNET_INSTALL_SKIP_PREREQS:-}" = "1" ]; then
-        return 0
-    fi
-
-    if [ "$(uname)" = "Linux" ]; then
-        if is_musl_based_distro; then
-            if ! command -v scanelf > /dev/null; then
-                say_warning "scanelf not found, please install pax-utils package."
-                return 0
-            fi
-            LDCONFIG_COMMAND="scanelf --ldpath -BF '%f'"
-            [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libintl)" ] && say_warning "Unable to locate libintl. Probable prerequisite missing; install libintl (or gettext)."
-        else
-            if [ ! -x "$(command -v ldconfig)" ]; then
-                say_verbose "ldconfig is not in PATH, trying /sbin/ldconfig."
-                LDCONFIG_COMMAND="/sbin/ldconfig"
-            else
-                LDCONFIG_COMMAND="ldconfig"
-            fi
-            local librarypath=${LD_LIBRARY_PATH:-}
-            LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${librarypath//:/ }"
-        fi
-
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep zlib)" ] && say_warning "Unable to locate zlib. Probable prerequisite missing; install zlib."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep ssl)" ] && say_warning "Unable to locate libssl. Probable prerequisite missing; install libssl."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libicu)" ] && say_warning "Unable to locate libicu. Probable prerequisite missing; install libicu."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep lttng)" ] && say_warning "Unable to locate liblttng. Probable prerequisite missing; install liblttng."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libcurl)" ] && say_warning "Unable to locate libcurl. Probable prerequisite missing; install libcurl."
-    fi
-
-    return 0
-}
-
 # args:
 # input - $1
 to_lowercase() {
@@ -1119,7 +1083,6 @@ if [ "$dry_run" = true ]; then
     exit 0
 fi
 
-check_pre_reqs
 install_dotnet
 
 bin_path="$(get_absolute_path "$(combine_paths "$install_root" "$bin_folder_relative_path")")"
@@ -1130,4 +1093,6 @@ else
     say "Binaries of dotnet can be found in $bin_path"
 fi
 
+say "Please note that the script does not resolve dependencies during installation."
+say "To check the list of dependencies, go to https://docs.microsoft.com/en-us/dotnet/core/install, select your operating system and check the \"Dependencies\" section."
 say "Installation finished successfully."


### PR DESCRIPTION
Concerns issues #6, #36, #72.

The dependencies check is currently broken: 
- it is out of date, 
- it is not full (and can't be full): for different versions, for runtime/SDK, there might be different sets of dependencies, 
- the warnings are misleading, as they do not specify that it is a library name, not a package name, which has not been found.

To support these checks properly (more/less full and not out of date) we would need too big of an effort. It is doubtful that some checks always are better than none: we are worried that the customer would see the warning, add the library, and would not understand why dotnet still does not work, as a result of incompleteness of a check.

Based on these, we decided to remove them and instead always ask the customer to visit the documentation page and to check the dependencies listed there. 