### PR TITLE
Add info messages concerning install scripts purpose

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -635,6 +635,11 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
     }
 }
 
+Say "Please note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+Say "- The SDK needs to be installed without user interaction and without admin rights."
+Say "- The SDK installation doesn't need to persist across multiple CI runs."
+Say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
+
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
 $SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -Channel $Channel -Version $Version -JSonFile $JSonFile
 $DownloadLink, $EffectiveVersion = Get-Download-Link -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1061,6 +1061,11 @@ if [ "$no_cdn" = true ]; then
     azure_feed="$uncached_feed"
 fi
 
+say "Please note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+say "- The SDK needs to be installed without user interaction and without admin rights."
+say "- The SDK installation doesn't need to persist across multiple CI runs."
+say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
+
 check_min_reqs
 calculate_vars
 script_name=$(basename "$0")


### PR DESCRIPTION
Delivers issue #43. Adding a warning so that people who want to install a runtime to run apps should use other installation options.