### PR TITLE
install scripts should remove temp zip file

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -619,6 +619,24 @@ function DownloadFile($Source, [string]$OutPath) {
     }
 }
 
+function SafeRemoveFile($Path) {
+	try {
+		if (Test-Path $Path) 
+		{
+			Remove-Item $Path
+			Say-Verbose "The temporary file `"$Path`" was removed."
+		}
+		else
+		{
+			Say-Verbose "The temporary file `"$Path`" does not exist, therefore is not removed."
+		}
+	}
+	catch
+	{
+		Say "Failed to remove the temporary file: `"$Path`", remove it manually."
+	}
+}
+
 function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolderRelativePath) {
     $BinPath = Get-Absolute-Path $(Join-Path -Path $InstallRoot -ChildPath $BinFolderRelativePath)
     if (-Not $NoPath) {
@@ -729,6 +747,8 @@ try {
 }
 catch {
     Say "Cannot download: $DownloadLink"
+	SafeRemoveFile -Path $ZipPath
+
     if ($LegacyDownloadLink) {
         $DownloadLink = $LegacyDownloadLink
         $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
@@ -739,6 +759,7 @@ catch {
         }
         catch {
             Say "Cannot download: $DownloadLink"
+			SafeRemoveFile -Path $ZipPath
             $DownloadFailed = $true
         }
     }
@@ -774,7 +795,7 @@ if (!$isAssetInstalled) {
     throw "`"$assetName`" with version = $SpecificVersion failed to install with an unknown error."
 }
 
-Remove-Item $ZipPath
+SafeRemoveFile -Path $ZipPath
 
 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
 

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -620,21 +620,20 @@ function DownloadFile($Source, [string]$OutPath) {
 }
 
 function SafeRemoveFile($Path) {
-	try {
-		if (Test-Path $Path) 
-		{
-			Remove-Item $Path
-			Say-Verbose "The temporary file `"$Path`" was removed."
-		}
-		else
-		{
-			Say-Verbose "The temporary file `"$Path`" does not exist, therefore is not removed."
-		}
-	}
-	catch
-	{
-		Say "Failed to remove the temporary file: `"$Path`", remove it manually."
-	}
+    try {
+        if (Test-Path $Path) {
+            Remove-Item $Path
+            Say-Verbose "The temporary file `"$Path`" was removed."
+        }
+        else
+        {
+            Say-Verbose "The temporary file `"$Path`" does not exist, therefore is not removed."
+        }
+    }
+    catch
+    {
+        Say "Failed to remove the temporary file: `"$Path`", remove it manually."
+    }
 }
 
 function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolderRelativePath) {
@@ -747,7 +746,7 @@ try {
 }
 catch {
     Say "Cannot download: $DownloadLink"
-	SafeRemoveFile -Path $ZipPath
+    SafeRemoveFile -Path $ZipPath
 
     if ($LegacyDownloadLink) {
         $DownloadLink = $LegacyDownloadLink
@@ -759,7 +758,7 @@ catch {
         }
         catch {
             Say "Cannot download: $DownloadLink"
-			SafeRemoveFile -Path $ZipPath
+            SafeRemoveFile -Path $ZipPath
             $DownloadFailed = $true
         }
     }

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -841,7 +841,7 @@ install_dotnet() {
     #  if the download fails, download the legacy_download_link
     if [ "$download_failed" = true ]; then
         say "Cannot download: $download_link"
-        rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
+        rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed"
         if [ "$valid_legacy_download_link" = true ]; then
             download_failed=false
             download_link="$legacy_download_link"
@@ -852,7 +852,7 @@ install_dotnet() {
 
             if [ "$download_failed" = true ]; then
                 say "Cannot download: $download_link"
-                rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
+                rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed"
             fi
         fi
     fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -692,6 +692,7 @@ extract_dotnet_package() {
     find "$temp_out_path" -type f | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
 
     rm -rf "$temp_out_path"
+	rm -f "$zip_path" && say_verbose "Temporary zip file $zip_path was removed"
 
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
@@ -840,7 +841,7 @@ install_dotnet() {
     #  if the download fails, download the legacy_download_link
     if [ "$download_failed" = true ]; then
         say "Cannot download: $download_link"
-
+		rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
         if [ "$valid_legacy_download_link" = true ]; then
             download_failed=false
             download_link="$legacy_download_link"
@@ -851,6 +852,7 @@ install_dotnet() {
 
             if [ "$download_failed" = true ]; then
                 say "Cannot download: $download_link"
+				rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
             fi
         fi
     fi
@@ -1074,27 +1076,27 @@ say "To set up a development environment or to run apps, use installers rather t
 
 check_min_reqs
 calculate_vars
-script_name=$(basename "$0")
+cscript_name=$(basename "$0")
 
-if [ "$dry_run" = true ]; then
-    say "Payload URLs:"
-    say "Primary named payload URL: $download_link"
-    if [ "$valid_legacy_download_link" = true ]; then
-        say "Legacy named payload URL: $legacy_download_link"
-    fi
-    repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"""
-    if [[ "$runtime" == "dotnet" ]]; then
-        repeatable_command+=" --runtime "\""dotnet"\"""
-    elif [[ "$runtime" == "aspnetcore" ]]; then
-        repeatable_command+=" --runtime "\""aspnetcore"\"""
-    fi
-    repeatable_command+="$non_dynamic_parameters"
-    say "Repeatable invocation: $repeatable_command"
+if [ "$dry_run" = true ]; then	
+    say "Payload URLs:"	
+    say "Primary named payload URL: $download_link"	
+    if [ "$valid_legacy_download_link" = true ]; then	
+        say "Legacy named payload URL: $legacy_download_link"	
+    fi	
+    repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"""	
+    if [[ "$runtime" == "dotnet" ]]; then	
+        repeatable_command+=" --runtime "\""dotnet"\"""	
+    elif [[ "$runtime" == "aspnetcore" ]]; then	
+        repeatable_command+=" --runtime "\""aspnetcore"\"""	
+    fi	
+    repeatable_command+="$non_dynamic_parameters"	
+    say "Repeatable invocation: $repeatable_command"	
     exit 0
 fi
 
-install_dotnet
 
+install_dotnet
 bin_path="$(get_absolute_path "$(combine_paths "$install_root" "$bin_folder_relative_path")")"
 if [ "$no_path" = false ]; then
     say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -692,7 +692,7 @@ extract_dotnet_package() {
     find "$temp_out_path" -type f | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
 
     rm -rf "$temp_out_path"
-	rm -f "$zip_path" && say_verbose "Temporary zip file $zip_path was removed"
+    rm -f "$zip_path" && say_verbose "Temporary zip file $zip_path was removed"
 
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
@@ -841,7 +841,7 @@ install_dotnet() {
     #  if the download fails, download the legacy_download_link
     if [ "$download_failed" = true ]; then
         say "Cannot download: $download_link"
-		rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
+        rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
         if [ "$valid_legacy_download_link" = true ]; then
             download_failed=false
             download_link="$legacy_download_link"
@@ -852,7 +852,7 @@ install_dotnet() {
 
             if [ "$download_failed" = true ]; then
                 say "Cannot download: $download_link"
-				rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
+                rm -f "$zip_path" 2>&1 && say_verbose "Temporary zip file $zip_path was removed or doesn't exist"
             fi
         fi
     fi
@@ -1076,27 +1076,27 @@ say "To set up a development environment or to run apps, use installers rather t
 
 check_min_reqs
 calculate_vars
-cscript_name=$(basename "$0")
+script_name=$(basename "$0")
 
-if [ "$dry_run" = true ]; then	
-    say "Payload URLs:"	
-    say "Primary named payload URL: $download_link"	
-    if [ "$valid_legacy_download_link" = true ]; then	
-        say "Legacy named payload URL: $legacy_download_link"	
-    fi	
-    repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"""	
-    if [[ "$runtime" == "dotnet" ]]; then	
-        repeatable_command+=" --runtime "\""dotnet"\"""	
-    elif [[ "$runtime" == "aspnetcore" ]]; then	
-        repeatable_command+=" --runtime "\""aspnetcore"\"""	
-    fi	
-    repeatable_command+="$non_dynamic_parameters"	
-    say "Repeatable invocation: $repeatable_command"	
+if [ "$dry_run" = true ]; then
+    say "Payload URLs:"
+    say "Primary named payload URL: $download_link"
+    if [ "$valid_legacy_download_link" = true ]; then
+        say "Legacy named payload URL: $legacy_download_link"
+    fi
+    repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"""
+    if [[ "$runtime" == "dotnet" ]]; then
+        repeatable_command+=" --runtime "\""dotnet"\"""
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        repeatable_command+=" --runtime "\""aspnetcore"\"""
+    fi
+    repeatable_command+="$non_dynamic_parameters"
+    say "Repeatable invocation: $repeatable_command"
     exit 0
 fi
 
-
 install_dotnet
+
 bin_path="$(get_absolute_path "$(combine_paths "$install_root" "$bin_folder_relative_path")")"
 if [ "$no_path" = false ]; then
     say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."


### PR DESCRIPTION
fixes dotnet/install-scripts#45:
- install-scripts.sh - temp zip file is now removed before script exits
- install-scripts.ps1 - added removing of zip file in case of download failure and log messages