### PR TITLE
#107 addressed monitoring failures due to uncaught exceptions

### DIFF
--- a/src/MonitoringFunctions.Common/DataService/IDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/IDataService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MonitoringFunctions.Models;
 using System;
 using System.Net.Http;
 using System.Threading;
@@ -16,6 +17,14 @@ namespace MonitoringFunctions
         /// <param name="httpResponse">Http response data to be stored.</param>
         /// <returns>A task, tracking the initiated async operation. Errors should be reported through exceptions.</returns>
         Task ReportUrlAccessAsync(string monitorName, HttpResponseMessage httpResponse, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Stores the details of the <see cref="HttpRequestLogEntry"/> in the underlying data store.
+        /// </summary>
+        /// <param name="httpRequestLogEntry"><see cref="HttpRequestLogEntry"/> to be stored.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> instance.</param>
+        /// <returns>A task, tracking the initiated async operation. Errors should be reported through exceptions.</returns>
+        Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stores the details of the <see cref="HttpResponseMessage"/> in the underlying data store.

--- a/src/MonitoringFunctions.Common/DataService/IDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/IDataService.cs
@@ -11,14 +11,6 @@ namespace MonitoringFunctions
     internal interface IDataService : IDisposable
     {
         /// <summary>
-        /// Stores the details of the <see cref="HttpResponseMessage"/> in the underlying data store.
-        /// </summary>
-        /// <param name="monitorName">Name of the monitor that will be associated with this data.</param>
-        /// <param name="httpResponse">Http response data to be stored.</param>
-        /// <returns>A task, tracking the initiated async operation. Errors should be reported through exceptions.</returns>
-        Task ReportUrlAccessAsync(string monitorName, HttpResponseMessage httpResponse, CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Stores the details of the <see cref="HttpRequestLogEntry"/> in the underlying data store.
         /// </summary>
         /// <param name="httpRequestLogEntry"><see cref="HttpRequestLogEntry"/> to be stored.</param>
@@ -27,10 +19,12 @@ namespace MonitoringFunctions
         Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Stores the details of the <see cref="HttpResponseMessage"/> in the underlying data store.
+        /// Stores the details of an install-script execution in the underlying data store.
         /// </summary>
-        /// <param name="monitorName">Name of the monitor that will be associated with this data.</param>
-        /// <param name="httpResponse">Http response data to be stored.</param>
+        /// <param name="monitorName">Name of the monitor generating this data entry.</param>
+        /// <param name="scriptName">Name of the script that was executed.</param>
+        /// <param name="commandLineArgs">Command line arguments passed to the script at the moment of execution.</param>
+        /// <param name="error">Errors that occured during the execution, if any.</param>
         /// <returns>A task, tracking the initiated async operation. Errors should be reported through exceptions.</returns>
         Task ReportScriptExecutionAsync(string monitorName, string scriptName, string commandLineArgs, string error, CancellationToken cancellationToken = default);
     }

--- a/src/MonitoringFunctions.Common/DataService/Providers/DummyDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/Providers/DummyDataService.cs
@@ -2,24 +2,24 @@
 
 using MonitoringFunctions.Models;
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace MonitoringFunctions.Providers
 {
+    /// <summary>
+    /// Mocks a data service. None of the method operate on a data store.
+    /// Instead, they wait for a random duration and return.
+    /// </summary>
     internal sealed class DummyDataService : IDataService
     {
-        public async Task ReportUrlAccessAsync(string monitorName, HttpResponseMessage httpResponse, CancellationToken cancellationToken = default)
-        {
-            await Task.Delay(new Random().Next(200, 4000), cancellationToken).ConfigureAwait(false);
-        }
-
+        /// <inheritdoc/>
         public async Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default)
         {
             await Task.Delay(new Random().Next(200, 4000), cancellationToken).ConfigureAwait(false);
         }
 
+        /// <inheritdoc/>
         public async Task ReportScriptExecutionAsync(string monitorName, string scriptName, string commandLineArgs, string error, CancellationToken cancellationToken = default)
         {
             await Task.Delay(new Random().Next(200, 4000), cancellationToken).ConfigureAwait(false);
@@ -29,6 +29,5 @@ namespace MonitoringFunctions.Providers
         {
             // Do nothing
         }
-
     }
 }

--- a/src/MonitoringFunctions.Common/DataService/Providers/DummyDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/Providers/DummyDataService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MonitoringFunctions.Models;
 using System;
 using System.Net.Http;
 using System.Threading;
@@ -10,6 +11,11 @@ namespace MonitoringFunctions.Providers
     internal sealed class DummyDataService : IDataService
     {
         public async Task ReportUrlAccessAsync(string monitorName, HttpResponseMessage httpResponse, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(new Random().Next(200, 4000), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default)
         {
             await Task.Delay(new Random().Next(200, 4000), cancellationToken).ConfigureAwait(false);
         }

--- a/src/MonitoringFunctions.Common/DataService/Providers/KustoDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/Providers/KustoDataService.cs
@@ -4,7 +4,6 @@ using Kusto.Data;
 using MonitoringFunctions.DataService.Kusto;
 using MonitoringFunctions.Models;
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,37 +35,18 @@ namespace MonitoringFunctions
         }
 
         /// <summary>
-        /// Reports the details of the <see cref="HttpResponseMessage"/> to kusto.
+        /// Stores the details of the <see cref="HttpRequestLogEntry"/> in the underlying kusto database.
         /// </summary>
-        /// <param name="monitorName">Name of the monitor generating this data entry.</param>
-        /// <param name="httpResponse">Response to be reported.</param>
-        /// <returns>A task, tracking this async operation.</returns>
-        public async Task ReportUrlAccessAsync(string monitorName, HttpResponseMessage httpResponse, CancellationToken cancellationToken = default)
-        {
-            HttpRequestLogEntry logEntry = new HttpRequestLogEntry()
-            {
-                MonitorName = monitorName,
-                EventTime = DateTime.UtcNow,
-                RequestedUrl = httpResponse.RequestMessage.RequestUri.AbsoluteUri,
-                HttpResponseCode = (int)httpResponse.StatusCode
-            };
-
-            await _httpRequestLogsTable.InsertRowAsync(logEntry, cancellationToken).ConfigureAwait(false);
-        }
-
+        /// <inheritdoc/>
         public async Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default)
         {
             await _httpRequestLogsTable.InsertRowAsync(httpRequestLogEntry, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Reports the details of a script execution to kusto.
+        /// Stores the details of an install-script execution in the underlying kusto database.
         /// </summary>
-        /// <param name="monitorName">Name of the monitor generating this data entry.</param>
-        /// <param name="scriptName">Name of the script that was executed.</param>
-        /// <param name="commandLineArgs">Command line arguments passed to the script at the moment of execution.</param>
-        /// <param name="error">Errors that occured during the execution, if any.</param>
-        /// <returns>A task, tracking this async operation.</returns>
+        /// <inheritdoc/>
         public async Task ReportScriptExecutionAsync(string monitorName, string scriptName, string commandLineArgs, string error, CancellationToken cancellationToken = default)
         {
             ScriptExecutionLogEntry logEntry = new ScriptExecutionLogEntry()

--- a/src/MonitoringFunctions.Common/DataService/Providers/KustoDataService.cs
+++ b/src/MonitoringFunctions.Common/DataService/Providers/KustoDataService.cs
@@ -54,6 +54,11 @@ namespace MonitoringFunctions
             await _httpRequestLogsTable.InsertRowAsync(logEntry, cancellationToken).ConfigureAwait(false);
         }
 
+        public async Task ReportUrlAccessAsync(HttpRequestLogEntry httpRequestLogEntry, CancellationToken cancellationToken = default)
+        {
+            await _httpRequestLogsTable.InsertRowAsync(httpRequestLogEntry, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Reports the details of a script execution to kusto.
         /// </summary>

--- a/src/MonitoringFunctions.Common/HelperMethods.cs
+++ b/src/MonitoringFunctions.Common/HelperMethods.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -21,12 +19,14 @@ namespace MonitoringFunctions
         private static readonly HttpClient _httpClient = new HttpClient();
 
         /// <summary>
-        /// Tests if the contents of the given url can be accessed from current environment.
-        /// Saves results to Kusto.
+        /// Tests if the contents of the given url can be accessed from the current environment.
+        /// Reports results to given data service.
         /// </summary>
         /// <param name="log"><see cref="ILogger"/> that is used to report log information.</param>
         /// <param name="monitorName">Name of this monitor to be included in the logs and in the data sent to Kusto.</param>
         /// <param name="url">Url that this method will attempt to access.</param>
+        /// <param name="dataService">Data service to be used when reporting the results.</param>
+        /// <param name="cancellationToken">Token to cancel the asynchronous operation.</param>
         /// <returns>A task, tracking the initiated async operation. Errors should be reported through exceptions.</returns>
         internal static async Task CheckAndReportUrlAccessAsync(ILogger log,
             string monitorName,
@@ -38,25 +38,48 @@ namespace MonitoringFunctions
             _ = string.IsNullOrWhiteSpace(monitorName) ? throw new ArgumentNullException(paramName: nameof(monitorName)) : monitorName;
             _ = string.IsNullOrWhiteSpace(url) ? throw new ArgumentNullException(paramName: nameof(url)) : url;
             _ = dataService ?? throw new ArgumentNullException(paramName: nameof(dataService));
+
+            HttpRequestLogEntry logEntry = new HttpRequestLogEntry()
+            {
+                MonitorName = monitorName,
+                EventTime = DateTime.UtcNow,
+                RequestedUrl = url
+            };
+            HttpResponseMessage? response = null;
             try
             {
-                using HttpResponseMessage response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                HttpRequestLogEntry entry = CreateHttpRequestLogEntry(monitorName, response.StatusCode, response.RequestMessage.RequestUri.AbsoluteUri);
-                await dataService.ReportUrlAccessAsync(entry, cancellationToken).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    log.LogInformation($"Monitor '{monitorName}' succeeded accessing url {url}.");
-                    return;
-                }
-                string error = $"Monitor '{monitorName}' failed accessing url {url} with error code {response.StatusCode}.";
-                log.LogError(error);
-                throw new Exception(error);
+                response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                logEntry.HttpResponseCode = (int)response.StatusCode;
+                await dataService.ReportUrlAccessAsync(logEntry, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception httpException)
             {
-                await dataService.ReportUrlAccessAsync(CreateHttpRequestLogEntry(monitorName, HttpStatusCode.InternalServerError, url), cancellationToken).ConfigureAwait(false);
-                log.LogError($"Monitor '{monitorName}' failed accessing url {url}.  Reason {e.Message}.");
-                throw e;
+                if (response == null)
+                {
+                    // HttpClient failed to return a response, instead threw. The error should be in the exception.
+                    logEntry.Error = httpException.Message;
+
+                    try
+                    {
+                        await dataService.ReportUrlAccessAsync(logEntry, cancellationToken);
+                    }
+                    catch (Exception dataServiceException)
+                    {
+                        // Reporting to database has failed. Let's report into Azure Functions so that we can somehow track this.
+                        log.LogError(httpException, $"Failed to access url {url} from monitor {monitorName}");
+                        // There was an error with the data store and this should also be logged.
+                        log.LogError(dataServiceException, "Failed to report an unsuccessful http request.");
+                    }
+                }
+                else
+                {
+                    // Http request completed, but reporting to data service has failed.
+                    log.LogError($"Failed to report an http response code {response.StatusCode} for url {url}.");
+                }
+            }
+            finally
+            {
+                response?.Dispose();
             }
         }
 
@@ -101,18 +124,6 @@ namespace MonitoringFunctions
 
             // Validate URL accessibility
             await HelperMethods.CheckAndReportUrlAccessAsync(log, monitorName, dryRunResults.PrimaryUrl, dataService);
-        }
-
-
-        private static HttpRequestLogEntry CreateHttpRequestLogEntry(string monitorName, HttpStatusCode httpStatus, string url)
-        {
-            return new HttpRequestLogEntry()
-            {
-                MonitorName = monitorName,
-                EventTime = DateTime.UtcNow,
-                RequestedUrl = url,
-                HttpResponseCode = (int)httpStatus
-            };
         }
     }
 }

--- a/src/MonitoringFunctions.Common/Models/HttpRequestLogEntry.cs
+++ b/src/MonitoringFunctions.Common/Models/HttpRequestLogEntry.cs
@@ -12,29 +12,55 @@ namespace MonitoringFunctions.Models
     /// </summary>
     internal struct HttpRequestLogEntry : IEquatable<HttpRequestLogEntry>, IKustoTableRow
     {
+        /// <summary>
+        /// Identifier for the monitor that generated this log entry.
+        /// </summary>
         [JsonProperty("monitor_name"), JsonRequired]
         public string? MonitorName { get; set; }
 
+        /// <summary>
+        /// The time that the http request was made.
+        /// </summary>
         [JsonProperty("timestamp"), JsonRequired]
         public DateTime EventTime { get; set; }
 
+        /// <summary>
+        /// Url
+        /// </summary>
         [JsonProperty("requested_url"), JsonRequired]
         public string? RequestedUrl { get; set; }
 
-        [JsonProperty("http_response_code"), JsonRequired]
+        /// <summary>
+        /// Http response code returned by the server.
+        /// The value is null if server couldn't be reached.
+        /// </summary>
+        [JsonProperty("http_response_code")]
         public int? HttpResponseCode { get; set; }
+
+        /// <summary>
+        /// Details of the error. This field can be used to determine the issue, in the case that 
+        /// an HttpResponseCode couldn't be retrieved because the server is unreachable.
+        /// </summary>
+        [JsonProperty("error")]
+        public string? Error { get; set; }
 
         public bool Equals([AllowNull] HttpRequestLogEntry other)
         {
             return MonitorName == other.MonitorName &&
                 EventTime == other.EventTime &&
                 RequestedUrl == other.RequestedUrl &&
-                HttpResponseCode == other.HttpResponseCode;
+                HttpResponseCode == other.HttpResponseCode &&
+                Error == other.Error;
         }
 
         public override string? ToString()
         {
-            return $"HttpRequestLogEntry - MonitorName: {MonitorName}, EventTime: {EventTime}, HttpResponseCode: {HttpResponseCode}, RequestedUrl: {RequestedUrl}";
+            return $"HttpRequestLogEntry - " +
+                $"MonitorName: {MonitorName}" +
+                $", EventTime: {EventTime}" +
+                $", HttpResponseCode: {HttpResponseCode}" +
+                $", RequestedUrl: {RequestedUrl}" +
+                $", Error: {Error}";
         }
     }
 }


### PR DESCRIPTION
Addresses #107 
Notes:
1. Updated IDataService with an ReportUrlAccessAsync overload, accepting an HttpRequestLogEntry instance
1. Updated the IDataService providers accordingly
1. HelperMethods.CheckAndReportUrlAccessAsync to use the new ReportUrlAccessAsync overload

The previous implementation, was instead relying on HttpResponseMessage instances which neither HelperMethods.CheckAndReportUrlAccessAsync nor the Kusto IDataService provider were disposing.