### PR TITLE
Fix exceptions' handling

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -796,7 +796,7 @@ catch {
     if ($PrimaryDownloadStatusCode -eq 404) {
         Say "The link $DownloadLink is not available."
     } else {
-        Say $PrimaryDownloadFailedMsg
+        Say $PSItem.Exception.Message
     }
 
     SafeRemoveFile -Path $ZipPath
@@ -822,7 +822,7 @@ catch {
             if ($LegacyDownloadStatusCode -eq 404) {
                 Say "The link $DownloadLink is not available."
             } else {
-                Say $LegacyDownloadFailedMsg
+                Say $PSItem.Exception.Message
             }
 
             SafeRemoveFile -Path $ZipPath
@@ -839,11 +839,12 @@ if ($DownloadFailed) {
         throw "Could not find `"$assetName`" with version = $SpecificVersion`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
     } else {
         # 404-NotFound is an expected response if it goes from only one of the links, do not show that error.
+        # If primary path is available (not 404-NotFound) then show the primary error else show the legacy error.
         if ($PrimaryDownloadStatusCode -ne "404") {
-            Say-Error $PrimaryDownloadFailedMsg
+            throw "Could not download `"$assetName`" with version = $SpecificVersion`r`n$PrimaryDownloadFailedMsg"
         }
         if (($LegacyDownloadLink) -and ($LegacyDownloadStatusCode -ne "404")) {
-            Say-Error $LegacyDownloadFailedMsg
+            throw "Could not download `"$assetName`" with version = $SpecificVersion`r`n$LegacyDownloadFailedMsg"
         }
         throw "Could not download `"$assetName`" with version = $SpecificVersion"
     }

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -289,16 +289,34 @@ function GetHTTPResponse([Uri] $Uri)
             $Task = $HttpClient.GetAsync("${Uri}${FeedCredential}").ConfigureAwait("false");
             $Response = $Task.GetAwaiter().GetResult();
             if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
-                 # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
-                $ErrorMsg = "Failed to download $Uri."
+                # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
+                $ErrorMsg = ""
                 if ($Response -ne $null) {
-                    $ErrorMsg += "  $Response"
+                    $ErrorMsg += "$Response"
                 }
-
                 throw $ErrorMsg
             }
 
             return $Response
+
+        }
+        catch {
+            $ErrorMsg = "Failed to download $Uri.`r`n"
+
+            # Pick up the exception message and inner exceptions' messages if they exist
+            $CurrentException = $PSItem.Exception
+            $ErrorMsg += $CurrentException.Message + "`r`n"
+            while ($CurrentException.InnerException) {
+              $CurrentException = $CurrentException.InnerException
+              $ErrorMsg += "  " + $CurrentException.Message + "`r`n"
+            }
+
+            # Check if there is an issue concerning TLS.
+            if ($ErrorMsg -like "*SSL/TLS*") {
+                $ErrorMsg += "Ensure that TLS 1.2 or higher is enabled to use this script.`r`n"
+            }
+
+            throw "$ErrorMsg"
         }
         finally {
              if ($HttpClient -ne $null) {
@@ -750,12 +768,21 @@ $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO
 Say-Verbose "Zip path: $ZipPath"
 
 $DownloadFailed = $false
+$DownloadFailedWithNon404Error = $false
+$DownloadFailedMsg = ""
 Say "Downloading link: $DownloadLink"
 try {
     DownloadFile -Source $DownloadLink -OutPath $ZipPath
 }
 catch {
-    Say "Cannot download: $DownloadLink"
+    if (($PSItem.Exception -like "*StatusCode: 404*")) {
+        Say "The primary path $DownloadLink is not available."
+    } else {
+        Say "Cannot download via the primary path $DownloadLink."
+        $DownloadFailedWithNon404Error = $true
+        $DownloadFailedMsg += $PSItem.Exception.Message + "`n"
+    }
+
     SafeRemoveFile -Path $ZipPath
 
     if ($LegacyDownloadLink) {
@@ -767,7 +794,14 @@ catch {
             DownloadFile -Source $DownloadLink -OutPath $ZipPath
         }
         catch {
-            Say "Cannot download: $DownloadLink"
+            if (($PSItem.Exception -like "*StatusCode: 404*")) {
+                Say "The legacy path $DownloadLink is not available."
+            } else {
+                Say "Cannot download via the legacy path $DownloadLink."
+                $DownloadFailedWithNon404Error = $true
+                $DownloadFailedMsg += $PSItem.Exception.Message + "`n"
+            }
+
             SafeRemoveFile -Path $ZipPath
             $DownloadFailed = $true
         }
@@ -778,7 +812,12 @@ catch {
 }
 
 if ($DownloadFailed) {
-    throw "Could not find/download: `"$assetName`" with version = $SpecificVersion`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
+    if ($DownloadFailedWithNon404Error) {
+        Say-Error "$DownloadFailedMsg"
+        throw "Could not download `"$assetName`" with version = $SpecificVersion"
+    } else {
+        throw "Could not find `"$assetName`" with version = $SpecificVersion`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
+    }
 }
 
 Say "Extracting zip from $DownloadLink"

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -787,6 +787,7 @@ catch {
     if ($PSItem.Exception.Data.Contains("StatusCode")) {
         $PrimaryDownloadStatusCode = $PSItem.Exception.Data["StatusCode"]
     }
+
     if ($PSItem.Exception.Data.Contains("ErrorMessage")) {
         $PrimaryDownloadFailedMsg = $PSItem.Exception.Data["ErrorMessage"]
     } else {
@@ -794,7 +795,7 @@ catch {
     }
 
     if ($PrimaryDownloadStatusCode -eq 404) {
-        Say "The link $DownloadLink is not available."
+        Say "The resource at $DownloadLink is not available."
     } else {
         Say $PSItem.Exception.Message
     }
@@ -813,6 +814,7 @@ catch {
             if ($PSItem.Exception.Data.Contains("StatusCode")) {
                 $LegacyDownloadStatusCode = $PSItem.Exception.Data["StatusCode"]
             }
+
             if ($PSItem.Exception.Data.Contains("ErrorMessage")) {
                 $LegacyDownloadFailedMsg = $PSItem.Exception.Data["ErrorMessage"]
             } else {
@@ -820,7 +822,7 @@ catch {
             }
 
             if ($LegacyDownloadStatusCode -eq 404) {
-                Say "The link $DownloadLink is not available."
+                Say "The resource at $DownloadLink is not available."
             } else {
                 Say $PSItem.Exception.Message
             }
@@ -835,15 +837,15 @@ catch {
 }
 
 if ($DownloadFailed) {
-    if (($PrimaryDownloadStatusCode -eq "404") -and ((-not $LegacyDownloadLink) -or ($LegacyDownloadStatusCode -eq "404"))) {
+    if (($PrimaryDownloadStatusCode -eq 404) -and ((-not $LegacyDownloadLink) -or ($LegacyDownloadStatusCode -eq 404))) {
         throw "Could not find `"$assetName`" with version = $SpecificVersion`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
     } else {
         # 404-NotFound is an expected response if it goes from only one of the links, do not show that error.
         # If primary path is available (not 404-NotFound) then show the primary error else show the legacy error.
-        if ($PrimaryDownloadStatusCode -ne "404") {
+        if ($PrimaryDownloadStatusCode -ne 404) {
             throw "Could not download `"$assetName`" with version = $SpecificVersion`r`n$PrimaryDownloadFailedMsg"
         }
-        if (($LegacyDownloadLink) -and ($LegacyDownloadStatusCode -ne "404")) {
+        if (($LegacyDownloadLink) -and ($LegacyDownloadStatusCode -ne 404)) {
             throw "Could not download `"$assetName`" with version = $SpecificVersion`r`n$LegacyDownloadFailedMsg"
         }
         throw "Could not download `"$assetName`" with version = $SpecificVersion"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -682,6 +682,7 @@ extract_dotnet_package() {
         say_err "Extraction failed"
         return 1
     fi
+    return 0
 }
 
 get_http_header_curl() {
@@ -915,7 +916,7 @@ install_dotnet() {
     fi
 
     say "Extracting zip from $download_link"
-    extract_dotnet_package "$zip_path" "$install_root"
+    extract_dotnet_package "$zip_path" "$install_root" || return 1
 
     #  Check if the SDK version is installed; if not, fail the installation.
     # if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -900,13 +900,16 @@ install_dotnet() {
             say_err "Could not find \`$asset_name\` with version = $specific_version"
             say_err "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
         else
-            say_err "Could not download: \`$asset_name\` with version = $specific_version:"
+            say_err "Could not download: \`$asset_name\` with version = $specific_version"
             # 404-NotFound is an expected response if it goes from only one of the links, do not show that error.
+            # If primary path is available (not 404-NotFound) then show the primary error else show the legacy error.
             if [ "$primary_path_http_code" != "404" ]; then
                 say_err "$primary_path_download_error_msg"
+                return 1
             fi
             if [[ "$valid_legacy_download_link" = true  && "$legacy_path_http_code" != "404" ]]; then
                 say_err "$legacy_path_download_error_msg"
+                return 1
             fi
         fi
         return 1

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -861,7 +861,7 @@ install_dotnet() {
     if [ "$download_failed" = true ]; then
         case $primary_path_http_code in
         404)
-            say "The link $download_link is not available."
+            say "The resource at $download_link is not available."
             ;;
         *)
             say "$primary_path_download_error_msg"
@@ -884,7 +884,7 @@ install_dotnet() {
             if [ "$download_failed" = true ]; then
                 case $legacy_path_http_code in
                 404)
-                    say "The link $download_link is not available."
+                    say "The resource at $download_link is not available."
                     ;;
                 *)
                     say "$legacy_path_download_error_msg"


### PR DESCRIPTION
Second PR concerning exceptions' handling. Addresses issues #27, #11, #9, #8.

Changes:
- Add functions for getting HTTP headers.
- Make download errors visible (including the TLS issue).
- Error 404 is now processed separately: for some of the cases, getting error 404 is a normal flow of script execution. 
- Fix extraction failure processing.