### PR TITLE
Fix default architecture detection

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -296,7 +296,7 @@ get_machine_architecture() {
     if command -v uname > /dev/null; then
         CPUName=$(uname -m)
         case $CPUName in
-        armv7l)
+        armv*l)
             echo "arm"
             return 0
             ;;


### PR DESCRIPTION
The changes fix the two situations when architecture detection is currently wrong:
- The kernel is 64-bit, the kernel truthfully reports that it is 64-bit, but the OS is 32-bit (removed, decided not to fix)
- The kernel is 64-bit, the kernel lies and reports that it is 32-bit, but the OS is 32-bit
