### PR TITLE
[draft] aka.ms links support

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -410,6 +410,9 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel) {
     else {
         throw "Invalid value for `$Runtime"
     }
+
+    Say-Verbose "Constructed latest.version URL: $VersionFileUrl"
+
     try {
         $Response = GetHTTPResponse -Uri $VersionFileUrl
     }
@@ -794,7 +797,7 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
     }
 }
 
-function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Product, [string]$Architecture) {    
+function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Product, [string]$Architecture) {
     Say-Invocation $MyInvocation 
 
     #quality is not supported for LTS or current channel

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -234,11 +234,11 @@ function Get-NormalizedQuality([string]$Quality) {
         return ""
     }
 
-    switch ($Quality.ToLower()) {
-        { ($_ -eq "daily") -or ($_ -eq "signed") -or ($_ -eq "validated") -or ($_ -eq "preview")} { return $Quality.ToLower() }
+    switch ($Quality) {
+        { @("daily", "signed", "validated", "preview") -contains $_ } { return $Quality.ToLower() }
         #ga quality is available without specifying quality, so normalizing it to empty
         { $_ -eq "ga" } { return "" }
-        default { throw "'$Quality' is not a supported value for --quality option, supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+        default { throw "'$Quality' is not a supported value for -Quality option, supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
     }
 }
 
@@ -249,8 +249,9 @@ function Get-NormalizedChannel([string]$Channel) {
         return ""
     }
 
-    switch ($Channel.ToLower()) {
+    switch ($Channel) {
         { $_ -eq "lts" } { return "LTS" }
+        { $_ -eq "current" } { return "current" }
         default { return $Channel.ToLower() }
     }
 }
@@ -258,19 +259,13 @@ function Get-NormalizedChannel([string]$Channel) {
 function Get-NormalizedProduct([string]$Runtime) {
     Say-Invocation $MyInvocation
 
-    if ($Runtime.ToLower() -eq "dotnet") {
-        $Product = "dotnet-runtime"
+    switch ($Runtime) {
+        { $_ -eq "dotnet" } { return "dotnet-runtime" }
+        { $_ -eq "aspnetcore" } { return "aspnetcore-runtime" }
+        { $_ -eq "windowsdesktop" } { return "windowsdesktop-runtime" }
+        { [string]::IsNullOrEmpty($_) } { return "dotnet-sdk" }
+        default { throw "'$Runtime' is not a supported value for -Runtime option, supported values are: dotnet, aspnetcore, windowsdesktop. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
     }
-    elseif ($Runtime.ToLower() -eq "aspnetcore") {
-        $Product = "aspnetcore-runtime"
-    }
-    elseif ($Runtime.ToLower() -eq "windowsdesktop") {
-        $Product = "windowsdesktop-runtime"
-    }
-    elseif ([string]::IsNullOrEmpty($runtime)) {
-        $Product = "dotnet-sdk"
-    }
-    return $Product
 }
 
 
@@ -805,7 +800,7 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
     Say-Invocation $MyInvocation 
 
     #quality is not supported for LTS or current channel
-    if (![string]::IsNullOrEmpty($Quality)  -and ($Channel -eq "LTS" -or $Channel -eq "current") ) {
+    if (![string]::IsNullOrEmpty($Quality) -and (@("LTS", "current") -contains $Channel)) {
         $Quality = ""
         Say-Warning "Specifying quality for current or LTS channel is not supported, the quality will skipped."
     }

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -805,7 +805,7 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
     Say-Invocation $MyInvocation 
 
     #quality is not supported for LTS or current channel
-    if ([string]::IsNullOrEmpty($Quality)  -and ($Channel -eq "LTS" -or $Channel -eq "current") ) {
+    if (![string]::IsNullOrEmpty($Quality)  -and ($Channel -eq "LTS" -or $Channel -eq "current") ) {
         $Quality = ""
         Say-Warning "Specifying quality for current or LTS channel is not supported, the quality will skipped."
     }

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -862,6 +862,7 @@ $NormalizedChannel = Get-NormalizedChannel $Channel
 Say-Verbose "Normalized channel: '$NormalizedChannel'"
 $NormalizedProduct = Get-NormalizedProduct $Runtime
 Say-Verbose "Normalized product: '$NormalizedProduct'"
+$DownloadLink = $null
 
 #try to get download location from aka.ms link
 #not applicable when exact version is specified via command or json file
@@ -876,7 +877,6 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version.ToLower() -eq "latest")) {
             throw "aka.ms link resolution failure"
         }
         Say-Verbose "Falling back to latest.version file approach."
-        $DownloadLink = $null
     }
     else {
         Say-Verbose "Retrieved primary named payload URL from aka.ms link: '$AkaMsDownloadLink'."

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -872,7 +872,7 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version.ToLower() -eq "latest")) {
     if ([string]::IsNullOrEmpty($AkaMsDownloadLink)){
         if (-not [string]::IsNullOrEmpty($NormalizedQuality)) {
             # if quality is specified - exit with error - there is no fallback approach
-            Say-Error "Failed to locate the latest version in channel '$NormalizedChannel' with '$NormalizedQuality' quality for '$NormalizedProduct', os: 'win', architecture: '$CLIArchitecture'."
+            Say-Error "Failed to locate the latest version in the channel '$NormalizedChannel' with '$NormalizedQuality' quality for '$NormalizedProduct', os: 'win', architecture: '$CLIArchitecture'."
             Say-Error "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support."
             throw "aka.ms link resolution failure"
         }

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -19,8 +19,6 @@
     - 3-part version in a format A.B.Cxx - represents a specific SDK release
           examples: 5.0.1xx, 5.0.2xx
           Supported since 5.0 release
-    - Branch name
-          example: release/2.0.0
     Note: The version parameter overrides the channel parameter when any version other than 'latest' is used.
 .PARAMETER Quality
     Download the latest build of specified quality in the channel. The possible values are: daily, signed, validated, preview, GA.
@@ -245,6 +243,10 @@ function Get-NormalizedChannel([string]$Channel) {
 
     if ([string]::IsNullOrEmpty($Channel)) {
         return ""
+    }
+
+    if ($Channel -eq "lts" -or $Channel -eq "current" -or $Channel.StartsWith('release/')) {
+        Say-Warning "Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead."
     }
 
     switch ($Channel) {

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -399,6 +399,11 @@ get_normalized_channel() {
     eval $invocation
 
     local channel="$(to_lowercase "$1")"
+
+    if [[ $channel == release/* ]] || [[ $channel == 'lts' ]] || [[ $channel == 'current' ]] ; then
+        say_warning 'Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead.';
+    fi
+
     if [ ! -z "$channel" ]; then
         case "$channel" in
             lts)
@@ -1389,8 +1394,6 @@ do
             echo "          - 3-part version in a format A.B.Cxx - represents a specific SDK release"
             echo "              examples: 5.0.1xx, 5.0.2xx."
             echo "              Supported since 5.0 release"
-            echo "          - Branch name"
-            echo "              examples: release/2.0.0; Master"
             echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used."
             echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$version\`."
             echo "      -Version"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -877,11 +877,10 @@ get_download_link_from_aka_ms() {
     #quality is not supported for LTS or current channel
     if [[ ! -z "$quality"  && ("$channel" == "LTS" || "$channel" == "Current") ]]; then
         quality=""
-        say "Specifying quality for current or LTS channel is not supported, the quality will skipped"
+        say_warning "Specifying quality for current or LTS channel is not supported, the quality will skipped"
     fi
 
     #TODO: check if any other restricions for channel should be applied
-
     say_verbose "Retrieving primary named payload URL from aka.ms for channel '$channel', quality '$quality' product '$product', os '$osname', architecture '$normalized_architecture'" 
 
     #construct aka.ms link

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -385,7 +385,7 @@ get_normalized_quality() {
                 return 0
                 ;;
             *)
-                say_err "'$quality' is not a supported value for --quality option, supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
+                say_err "'$quality' is not a supported value for --quality option. Supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
                 return 1
                 ;;
         esac
@@ -676,7 +676,7 @@ get_product_specific_version_from_download_link()
     filename="${download_link##*/}"
 
     #product specific version follows the product name
-    #for filename 'dotnet-sdk-3.1.404-linux-x64.tar.gz': the product version is 3.1.400
+    #for filename 'dotnet-sdk-3.1.404-linux-x64.tar.gz': the product version is 3.1.404
     IFS='-'
     read -ra filename_elems <<< "$filename"
     count=${#filename_elems[@]}
@@ -819,6 +819,8 @@ extract_dotnet_package() {
     return 0
 }
 
+# args:
+# remote_path - $1
 get_http_header()
 {
     eval $invocation
@@ -839,6 +841,8 @@ get_http_header()
     return 0
 }
 
+# args:
+# remote_path - $1
 get_http_header_curl() {
     eval $invocation
     local remote_path="$1"
@@ -848,6 +852,8 @@ get_http_header_curl() {
     return 0
 }
 
+# args:
+# remote_path - $1
 get_http_header_wget() {
     eval $invocation
     local remote_path="$1"
@@ -968,7 +974,7 @@ get_download_link_from_aka_ms() {
     #quality is not supported for LTS or current channel
     if [[ ! -z "$normalized_quality"  && ("$normalized_channel" == "LTS" || "$normalized_channel" == "current") ]]; then
         normalized_quality=""
-        say_warning "Specifying quality for current or LTS channel is not supported, the quality will skipped."
+        say_warning "Specifying quality for current or LTS channel is not supported, the quality will be ignored."
     fi
 
     say_verbose "Retrieving primary payload URL from aka.ms for channel: '$normalized_channel', quality: '$normalized_quality', product: '$normalized_product', os: '$normalized_os', architecture: '$normalized_architecture'." 
@@ -1038,7 +1044,7 @@ calculate_vars() {
                 say_verbose "Retrieved primary payload URL from aka.ms link: '$aka_ms_download_link'."
                 download_link=$aka_ms_download_link
 
-                say_verbose "Attempting legacy download location will be skipped."
+                say_verbose "Downloading using legacy url will not be attempted."
                 valid_legacy_download_link=false
 
                 #get version from the path
@@ -1341,7 +1347,7 @@ do
             echo "              Supported since 5.0 release"
             echo "          - Branch name"
             echo "              examples: release/2.0.0; Master"
-            echo "          Note: The version parameter overrides the channel parameter when the version other than `latest` is used."
+            echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used."
             echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$version\`."
             echo "      -Version"
             echo "          Possible values:"
@@ -1351,10 +1357,10 @@ do
             echo "  -q,--quality <quality>         Download the latest build of specified quality in the channel."
             echo "      -Quality"
             echo "          The possible values are: daily, signed, validated, preview, GA."
-            echo "          Works only in combination in with channel. Not applicable for current and LTS channels and will be skipped if those channels are used." 
+            echo "          Works only in combination with channel. Not applicable for current and LTS channels and will be ignored if those channels are used." 
             echo "          For SDK use channel in A.B.Cxx format. Using quality for SDK together with channel in A.B format is not supported." 
             echo "          Supported since 5.0 release." 
-            echo "          Note: The version parameter overrides the channel parameter when the version other than `latest` is used, and therefore overrides the quality."
+            echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used, and therefore overrides the quality."
             echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -128,6 +128,12 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("6.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/6.0/daily/windowsdesktop-runtime-")]
         public void Runtime_IntegrationTest(string channel, string runtime, string quality, string expectedLink)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
+            {
+                // Do not run windowsdesktop tests on Linux environment.
+                return;
+            }
+
             string expectedLinkPattern = Regex.Escape(expectedLink);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -239,7 +245,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
             {
-                //do not run windowsdesktop test on Linux environment
+                // Do not run windowsdesktop tests on Linux environment.
                 return;
             }
 
@@ -284,7 +290,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
             {
-                //do not run windowsdesktop test on Linux environment
+                // Do not run windowsdesktop tests on Linux environment.
                 return;
             }
 
@@ -326,7 +332,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
             {
-                //do not run windowsdesktop test on Linux environment
+                // Do not run windowsdesktop tests on Linux environment.
                 return;
             }
 

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .Execute();
 
             commandResult.Should().Fail();
-            commandResult.Should().HaveStdErrContaining("Failed to locate the latest version in channel");
+            commandResult.Should().HaveStdErrContaining("Failed to locate the latest version in the channel");
 
         }
 

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
-    public class AkaMsLinksTests
+    public class AkaMsLinksTests : TestBase
     {
         /// <summary>
         /// Test verifies E2E the aka.ms resolution for SDK
@@ -360,43 +360,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().Pass();
             commandResult.Should().NotHaveStdOutContaining("Retrieving primary payload URL from aka.ms link for channel");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
-        }
-
-
-        private static Command CreateInstallCommand(IEnumerable<string> args)
-        {
-            string path;
-            string finalArgs;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                path = "powershell.exe";
-                finalArgs = "-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"" +
-                    Path.Combine(GetRepoRoot(), "src", "dotnet-install.ps1") + " " + ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args) + "\"";
-            }
-            else
-            {
-                path = Path.Combine(GetRepoRoot(), "src", "dotnet-install.sh");
-                finalArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
-            }
-
-            return Command.Create(new CommandSpec(path, finalArgs, CommandResolutionStrategy.None));
-        }
-
-        private static string GetRepoRoot()
-        {
-            string directory = AppContext.BaseDirectory;
-
-            while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
-            {
-                directory = Directory.GetParent(directory)?.FullName;
-            }
-
-            if (directory == null)
-            {
-                return null;
-            }
-            return directory;
         }
     }
 }

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -15,23 +15,32 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         /// <summary>
         /// Test verifies E2E the aka.ms resolution for SDK
         /// </summary>
-        [Theory (Skip = "disabled until aka.ms links are implemented")]
-        [InlineData("1.0", null, @"https://aka.ms/dotnet/1.0/dotnet-sdk-")]
-        [InlineData("1.1", null, @"https://aka.ms/dotnet/1.1/dotnet-sdk-")]
-        [InlineData("2.0", null, @"https://aka.ms/dotnet/2.0/dotnet-sdk-")]
-        [InlineData("2.1", null, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
-        [InlineData("3.0", null, @"https://aka.ms/dotnet/3.0/dotnet-sdk-")]
-        [InlineData("3.1", null, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
-        [InlineData("5.0", null, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
-        [InlineData("5.0.1xx", null, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
-        [InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
-        [InlineData("Current", null, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
-        [InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        [Theory]
+        // aka.ms links don't work for versions before 6.0 yet
+        //[InlineData("1.0", null, @"https://aka.ms/dotnet/1.0/dotnet-sdk-")]
+        //[InlineData("1.1", null, @"https://aka.ms/dotnet/1.1/dotnet-sdk-")]
+        //[InlineData("2.0", null, @"https://aka.ms/dotnet/2.0/dotnet-sdk-")]
+        //[InlineData("2.1", null, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
+        //[InlineData("3.0", null, @"https://aka.ms/dotnet/3.0/dotnet-sdk-")]
+        //[InlineData("3.1", null, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
+        //[InlineData("5.0", null, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
+        //[InlineData("5.0.1xx", null, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        //[InlineData("Current", null, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
+        //[InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
+        //[InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        
+        // 6.0 doesn't have a signed. validated, preview or ga build yet.
+        // [InlineData("6.0", "signed", @"https://aka.ms/dotnet/6.0/signed/dotnet-sdk-")]
+        //[InlineData("6.0", "validated", @"https://aka.ms/dotnet/6.0/validated/dotnet-sdk-")]
+        //[InlineData("6.0", "preview", @"https://aka.ms/dotnet/6.0/preview/dotnet-sdk-")]
+        //[InlineData("6.0", "ga", @"https://aka.ms/dotnet/6.0/dotnet-sdk-")]
+
+        [InlineData("6.0", "daily", @"https://aka.ms/dotnet/6.0/daily/dotnet-sdk-")]
         public void SDK_IntegrationTest(string channel, string quality, string expectedLink)
         {
             string expectedLinkPattern = Regex.Escape(expectedLink);
@@ -61,7 +70,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().Pass();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
             commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
-            commandResult.Should().HaveStdOutContaining("Attempting legacy download location will be skipped.");
+            commandResult.Should().HaveStdOutContaining("Downloading using legacy url will not be attempted.");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
             commandResult.Should().NotHaveStdOutContaining("Falling back to latest.version file approach.");
@@ -71,43 +80,52 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         /// <summary>
         /// Test verifies E2E the aka.ms resolution for runtimes
         /// </summary>
-        [Theory(Skip = "disabled until aka.ms links are implemented")]
-        [InlineData("1.0", "dotnet", null, @"https://aka.ms/dotnet/1.0/dotnet-runtime-")]
-        [InlineData("1.1", "dotnet", null, @"https://aka.ms/dotnet/1.1/dotnet-runtime-")]
-        [InlineData("2.0", "dotnet", null, @"https://aka.ms/dotnet/2.0/dotnet-runtime-")]
-        [InlineData("2.1", "dotnet", null, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
-        [InlineData("3.0", "dotnet", null, @"https://aka.ms/dotnet/3.0/dotnet-runtime-")]
-        [InlineData("3.1", "dotnet", null, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
-        [InlineData("Current", "dotnet", null, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
-        [InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
-        [InlineData("2.0", "aspnetcore", null, @"https://aka.ms/dotnet/2.0/aspnetcore-runtime-")]
-        [InlineData("2.1", "aspnetcore", null, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
-        [InlineData("3.0", "aspnetcore", null, @"https://aka.ms/dotnet/3.0/aspnetcore-runtime-")]
-        [InlineData("3.1", "aspnetcore", null, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
-        [InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
-        [InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
-        [InlineData("3.0", "windowsdesktop", null, @"https://aka.ms/dotnet/3.0/windowsdesktop-runtime-")]
-        [InlineData("3.1", "windowsdesktop", null, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
-        [InlineData("Current", "windowsdesktop", null, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
-        [InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        [Theory]
+        // aka.ms links don't work for versions before 6.0 yet
+        //[InlineData("1.0", "dotnet", null, @"https://aka.ms/dotnet/1.0/dotnet-runtime-")]
+        //[InlineData("1.1", "dotnet", null, @"https://aka.ms/dotnet/1.1/dotnet-runtime-")]
+        //[InlineData("2.0", "dotnet", null, @"https://aka.ms/dotnet/2.0/dotnet-runtime-")]
+        //[InlineData("2.1", "dotnet", null, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
+        //[InlineData("3.0", "dotnet", null, @"https://aka.ms/dotnet/3.0/dotnet-runtime-")]
+        //[InlineData("3.1", "dotnet", null, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        //[InlineData("Current", "dotnet", null, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
+        //[InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
+        //[InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        //[InlineData("2.0", "aspnetcore", null, @"https://aka.ms/dotnet/2.0/aspnetcore-runtime-")]
+        //[InlineData("2.1", "aspnetcore", null, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
+        //[InlineData("3.0", "aspnetcore", null, @"https://aka.ms/dotnet/3.0/aspnetcore-runtime-")]
+        //[InlineData("3.1", "aspnetcore", null, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        //[InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
+        //[InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
+        //[InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        //[InlineData("3.0", "windowsdesktop", null, @"https://aka.ms/dotnet/3.0/windowsdesktop-runtime-")]
+        //[InlineData("3.1", "windowsdesktop", null, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        //[InlineData("Current", "windowsdesktop", null, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
+        //[InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
+        //[InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+
+        // 6.0 doesn't have a signed. validated, preview or ga build yet.
+        // [InlineData("6.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/6.0/signed/windowsdesktop-runtime-")]
+        // [InlineData("6.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/6.0/validated/windowsdesktop-runtime-")]
+        // [InlineData("6.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/6.0/preview/windowsdesktop-runtime-")]
+        // [InlineData("6.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/6.0/windowsdesktop-runtime-")]
+        
+        [InlineData("6.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/6.0/daily/windowsdesktop-runtime-")]
         public void Runtime_IntegrationTest(string channel, string runtime, string quality, string expectedLink)
         {
             string expectedLinkPattern = Regex.Escape(expectedLink);
@@ -137,7 +155,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().Pass();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
             commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
-            commandResult.Should().HaveStdOutContaining("Attempting legacy download location will be skipped.");
+            commandResult.Should().HaveStdOutContaining("Downloading using legacy url will not be attempted.");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
             commandResult.Should().NotHaveStdOutContaining("Falling back to latest.version file approach.");

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -1,0 +1,402 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using Xunit;
+using System.Collections.Generic;
+using Microsoft.NET.TestFramework.Assertions;
+using FluentAssertions;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.InstallationScript.Tests
+{
+    public class AkaMsLinksTests
+    {
+        /// <summary>
+        /// Test verifies E2E the aka.ms resolution for SDK
+        /// </summary>
+        [Theory (Skip = "disabled until aka.ms links are implemented")]
+        [InlineData("1.0", null, @"https://aka.ms/dotnet/1.0/dotnet-sdk-")]
+        [InlineData("1.1", null, @"https://aka.ms/dotnet/1.1/dotnet-sdk-")]
+        [InlineData("2.0", null, @"https://aka.ms/dotnet/2.0/dotnet-sdk-")]
+        [InlineData("2.1", null, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
+        [InlineData("3.0", null, @"https://aka.ms/dotnet/3.0/dotnet-sdk-")]
+        [InlineData("3.1", null, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
+        [InlineData("5.0", null, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
+        [InlineData("5.0.1xx", null, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
+        [InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        [InlineData("Current", null, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
+        [InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        public void SDK_IntegrationTest(string channel, string quality, string expectedLink)
+        {
+            string expectedLinkPattern = Regex.Escape(expectedLink);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedLinkPattern += "win";
+            }
+            else
+            {
+                expectedLinkPattern += "(linux|linux-musl|osx)";
+            }
+
+            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose" };
+            if (!string.IsNullOrWhiteSpace(quality))
+            {
+                args.Add("-quality");
+                args.Add(quality);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+            commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
+            commandResult.Should().HaveStdOutContaining("Attempting legacy download location will be skipped.");
+            commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
+            commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
+            commandResult.Should().NotHaveStdOutContaining("Falling back to latest.version file approach.");
+            commandResult.Should().NotHaveStdOutContaining("Legacy named payload URL: ");
+        }
+
+        /// <summary>
+        /// Test verifies E2E the aka.ms resolution for runtimes
+        /// </summary>
+        [Theory(Skip = "disabled until aka.ms links are implemented")]
+        [InlineData("1.0", "dotnet", null, @"https://aka.ms/dotnet/1.0/dotnet-runtime-")]
+        [InlineData("1.1", "dotnet", null, @"https://aka.ms/dotnet/1.1/dotnet-runtime-")]
+        [InlineData("2.0", "dotnet", null, @"https://aka.ms/dotnet/2.0/dotnet-runtime-")]
+        [InlineData("2.1", "dotnet", null, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
+        [InlineData("3.0", "dotnet", null, @"https://aka.ms/dotnet/3.0/dotnet-runtime-")]
+        [InlineData("3.1", "dotnet", null, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("Current", "dotnet", null, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
+        [InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("2.0", "aspnetcore", null, @"https://aka.ms/dotnet/2.0/aspnetcore-runtime-")]
+        [InlineData("2.1", "aspnetcore", null, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
+        [InlineData("3.0", "aspnetcore", null, @"https://aka.ms/dotnet/3.0/aspnetcore-runtime-")]
+        [InlineData("3.1", "aspnetcore", null, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
+        [InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("3.0", "windowsdesktop", null, @"https://aka.ms/dotnet/3.0/windowsdesktop-runtime-")]
+        [InlineData("3.1", "windowsdesktop", null, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        [InlineData("Current", "windowsdesktop", null, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
+        [InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        public void Runtime_IntegrationTest(string channel, string runtime, string quality, string expectedLink)
+        {
+            string expectedLinkPattern = Regex.Escape(expectedLink);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedLinkPattern += "win";
+            }
+            else
+            {
+                expectedLinkPattern += "(linux|linux-musl|osx)";
+            }
+
+            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-runtime", runtime };
+            if (!string.IsNullOrWhiteSpace(quality))
+            {
+                args.Add("-quality");
+                args.Add(quality);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+            commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
+            commandResult.Should().HaveStdOutContaining("Attempting legacy download location will be skipped.");
+            commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
+            commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
+            commandResult.Should().NotHaveStdOutContaining("Falling back to latest.version file approach.");
+            commandResult.Should().NotHaveStdOutContaining("Legacy named payload URL: ");
+        }
+
+        [Theory]
+        [InlineData("2.1", null, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
+        [InlineData("3.1", null, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
+        [InlineData("5.0", null, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
+        [InlineData("5.0.1xx", null, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
+        [InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        [InlineData("Current", null, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
+        [InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        public void LinkCanBeCreatedForSdk(string channel, string quality, string expectedLink)
+        {
+            string expectedLinkPattern = Regex.Escape(expectedLink);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedLinkPattern += "win";
+            }
+            else
+            {
+                expectedLinkPattern += "(linux|linux-musl|osx)";
+            }
+
+            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose" };
+
+            if (!string.IsNullOrWhiteSpace (quality))
+            {
+                args.Add("-quality");
+                args.Add(quality);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+        }
+
+        [Theory]
+        [InlineData("2.1", "dotnet", null, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
+        [InlineData("3.1", "dotnet", null, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("Current", "dotnet", null, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
+        [InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("2.1", "aspnetcore", null, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
+        [InlineData("3.1", "aspnetcore", null, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
+        [InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("3.1", "windowsdesktop", null, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        [InlineData("Current", "windowsdesktop", null, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
+        [InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        public void LinkCanBeCreatedForGivenRuntime(string channel, string runtime, string quality, string expectedLink)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
+            {
+                //do not run windowsdesktop test on Linux environment
+                return;
+            }
+
+            string expectedLinkPattern = Regex.Escape(expectedLink);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedLinkPattern += "win";
+            }
+            else
+            {
+                expectedLinkPattern += "(linux|linux-musl|osx)";
+            }
+
+            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-runtime", runtime };
+
+            if (!string.IsNullOrWhiteSpace(quality))
+            {
+                args.Add("-quality");
+                args.Add(quality);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+        }
+
+        [Theory]
+        [InlineData("Current", null, "daily", @"https://aka.ms/dotnet/current/dotnet-sdk-")]
+        [InlineData("LTS", null, "signed", @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
+        [InlineData("Current", "dotnet", "validated", @"https://aka.ms/dotnet/current/dotnet-runtime-")]
+        [InlineData("LTS", "dotnet", "preview", @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
+        [InlineData("Current", "aspnetcore", "daily", @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
+        [InlineData("LTS", "aspnetcore", "signed", @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
+        [InlineData("Current", "windowsdesktop", "validated", @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
+        [InlineData("LTS", "windowsdesktop", "preview", @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
+        public void QualityIsSkippedForLTSAndCurrentChannel(string channel, string runtime, string quality, string expectedLink)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
+            {
+                //do not run windowsdesktop test on Linux environment
+                return;
+            }
+
+            string expectedLinkPattern = Regex.Escape(expectedLink);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedLinkPattern += "win";
+            }
+            else
+            {
+                expectedLinkPattern += "(linux|linux-musl|osx)";
+            }
+
+            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-quality", quality };
+
+            if (!string.IsNullOrWhiteSpace(runtime))
+            {
+                args.Add("-runtime");
+                args.Add(runtime);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().HaveStdOutContaining("Specifying quality for current or LTS channel is not supported, the quality will skipped.");
+            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+        }
+
+        [Theory]
+        [InlineData("Fake", null, "daily")]
+        [InlineData("Fake", "dotnet", "validated")]
+        [InlineData("Fake", "aspnetcore", "daily")]
+        [InlineData("Fake", "windowsdesktop", "validated")]
+        public void NoFallbackIfQualityIsGiven(string channel, string runtime, string quality)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
+            {
+                //do not run windowsdesktop test on Linux environment
+                return;
+            }
+
+            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-quality", quality };
+
+            if (!string.IsNullOrWhiteSpace(runtime))
+            {
+                args.Add("-runtime");
+                args.Add(runtime);
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Fail();
+            commandResult.Should().HaveStdErrContaining("Failed to locate the latest version in channel");
+
+        }
+
+        [Fact]
+        public void AkaMsLinkIsNotUsedWhenExactVersionIsSpecified()
+        {
+            var args = new string[] { "-dryrun", "-version", "3.1.100", "-verbose" };
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdOutContaining("Retrieving primary payload URL from aka.ms link for channel");
+            commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
+        }
+
+        [Fact]
+        public void AkaMsLinkIsNotUsedWhenExactVersionInJsonFileIsSpecified()
+        {
+            var installationScriptTestsJsonFile = Path.Combine(Environment.CurrentDirectory,
+              "Assets", "InstallationScriptTests.json");
+            var args = new string[] { "-dryrun", "-jsonfile", installationScriptTestsJsonFile, "-verbose" };
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdOutContaining("Retrieving primary payload URL from aka.ms link for channel");
+            commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
+        }
+
+
+        private static Command CreateInstallCommand(IEnumerable<string> args)
+        {
+            string path;
+            string finalArgs;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                path = "powershell.exe";
+                finalArgs = "-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"" +
+                    Path.Combine(GetRepoRoot(), "src", "dotnet-install.ps1") + " " + ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args) + "\"";
+            }
+            else
+            {
+                path = Path.Combine(GetRepoRoot(), "src", "dotnet-install.sh");
+                finalArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
+            }
+
+            return Command.Create(new CommandSpec(path, finalArgs, CommandResolutionStrategy.None));
+        }
+
+        private static string GetRepoRoot()
+        {
+            string directory = AppContext.BaseDirectory;
+
+            while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
+            {
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            if (directory == null)
+            {
+                return null;
+            }
+            return directory;
+        }
+    }
+}

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().HaveStdOutContaining("Specifying quality for current or LTS channel is not supported, the quality will skipped.");
+            commandResult.Should().HaveStdOutContaining("Specifying quality for current or LTS channel is not supported, the quality will be ignored.");
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
         }
 

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -11,7 +11,7 @@ using FluentAssertions;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
-    public class GivenThatIWantToGetTheSdkLinksFromAScript
+    public class GivenThatIWantToGetTheSdkLinksFromAScript : TestBase
     {
         [Theory]
         [InlineData("InstallationScriptTests.json")]
@@ -210,7 +210,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             //  Channel should be translated to a specific SDK version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
         }
-
         [Theory]
         [InlineData("5.0.1", "WindowsDesktop")]
         [InlineData("3.1.10", "Runtime")]
@@ -231,40 +230,5 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().Pass().And.HaveStdOutContaining(expectedLinkLog);
         } 
 
-        private static Command CreateInstallCommand(IEnumerable<string> args)
-        {
-            string path;
-            string finalArgs;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                path = "powershell.exe";
-                finalArgs = "-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"" +
-                    Path.Combine(GetRepoRoot(), "src", "dotnet-install.ps1") + " " + ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args) + "\"";
-            }
-            else
-            {
-                path = Path.Combine(GetRepoRoot(), "src", "dotnet-install.sh");
-                finalArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
-            }
-
-            return Command.Create(new CommandSpec(path, finalArgs, CommandResolutionStrategy.None));
-        }
-
-        private static string GetRepoRoot()
-        {
-            string directory = AppContext.BaseDirectory;
-
-            while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
-            {
-                directory = Directory.GetParent(directory)?.FullName;
-            }
-
-            if (directory == null)
-            {
-                return null;
-            }
-            return directory;
-        }
     }
 }

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -28,7 +28,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("3.0", "3\\.0\\..*", Quality.None),
                 ("3.1", "3\\.1\\..*", Quality.None),
                 ("5.0", "5\\.0\\..*", Quality.None),
-                ("6.0-preview2", "6\\.0\\..*", Quality.All),
                 ("6.0", "6\\.0\\..*", Quality.Daily),
                 ("Current", "5\\.0\\..*", Quality.None),
                 ("LTS", "3\\.1\\..*", Quality.None),
@@ -37,30 +36,32 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         /// <summary>
         /// All the branches in runtime repos to be tested
         /// </summary>
-        private static readonly IReadOnlyList<(string branch, string versionRegex)> _runtimeBranches =
-            new List<(string, string)>()
+        private static readonly IReadOnlyList<(string branch, string versionRegex, Quality quality)> _runtimeBranches =
+            new List<(string, string, Quality)>()
             {
-                ("release/2.1", "2\\.1\\..*"),
-                ("release/2.2", "2\\.2\\..*"),
-                ("release/3.0", "3\\.0\\..*"),
-                ("release/3.1", "3\\.1\\..*"),
-                ("release/5.0", "5\\.0\\..*"),
-                // branches are no longer supported starting 6.0
+                ("release/2.1", "2\\.1\\..*", Quality.None),
+                ("release/2.2", "2\\.2\\..*", Quality.None),
+                ("release/3.0", "3\\.0\\..*", Quality.None),
+                ("release/3.1", "3\\.1\\..*", Quality.None),
+                ("release/5.0", "5\\.0\\..*", Quality.None),
+                // Branches are no longer supported starting 6.0, but there are channels that correspond to branches.
+                ("6.0-preview2", "6\\.0\\..*", Quality.Daily | Quality.Signed),
             };
 
         /// <summary>
         /// All the branches in installer repo to be tested
         /// </summary>
-        private static readonly IReadOnlyList<(string branch, string versionRegex)> _sdkBranches =
-            new List<(string, string)>()
+        private static readonly IReadOnlyList<(string branch, string versionRegex, Quality quality)> _sdkBranches =
+            new List<(string, string, Quality)>()
             {
-                ("release/2.1.8xx", "2\\.1\\.8.*"),
-                ("release/2.2.4xx", "2\\.2\\.4.*"),
-                ("release/3.0.1xx", "3\\.0\\.1.*"),
-                ("release/3.1.4xx", "3\\.1\\.4.*"),
-                ("release/5.0.1xx", "5\\.0\\.1.*"),
-                ("release/5.0.2xx", "5\\.0\\.2.*"),
-                // branches are no longer supported starting 6.0
+                ("release/2.1.8xx", "2\\.1\\.8.*", Quality.None),
+                ("release/2.2.4xx", "2\\.2\\.4.*", Quality.None),
+                ("release/3.0.1xx", "3\\.0\\.1.*", Quality.None),
+                ("release/3.1.4xx", "3\\.1\\.4.*", Quality.None),
+                ("release/5.0.1xx", "5\\.0\\.1.*", Quality.None),
+                ("release/5.0.2xx", "5\\.0\\.2.*", Quality.None),
+                // Branches are no longer supported starting 6.0, but there are channels that correspond to branches.
+                ("6.0.1xx-preview2", "6\\.0\\.1.*", Quality.Daily | Quality.Signed),
             };
 
         public static IEnumerable<object?[]> InstallSdkFromChannelTestCases
@@ -70,12 +71,15 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // Download SDK using branches as channels.
                 foreach (var sdkBranchInfo in _sdkBranches)
                 {
-                    yield return new object?[]
+                    foreach (string quality in GetQualityOptionsFromFlags(sdkBranchInfo.quality).DefaultIfEmpty())
                     {
-                        sdkBranchInfo.branch,
-                        /*Quality:*/ null,
-                        sdkBranchInfo.versionRegex,
-                    };
+                        yield return new object?[]
+                        {
+                            sdkBranchInfo.branch,
+                            quality,
+                            sdkBranchInfo.versionRegex,
+                        };
+                    }
                 }
 
                 // Download SDK from darc channels.
@@ -101,12 +105,15 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // Download runtimes using branches as channels.
                 foreach (var runtimeBranchInfo in _runtimeBranches)
                 {
-                    yield return new object?[]
+                    foreach (string quality in GetQualityOptionsFromFlags(runtimeBranchInfo.quality).DefaultIfEmpty())
                     {
-                        runtimeBranchInfo.branch,
-                        /*Quality:*/ null,
-                        runtimeBranchInfo.versionRegex,
-                    };
+                        yield return new object?[]
+                        {
+                            runtimeBranchInfo.branch,
+                            quality,
+                            runtimeBranchInfo.versionRegex,
+                        };
+                    }
                 }
 
                 // Download runtimes using darc channels.

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -246,7 +246,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         {
             if (channel == "release/3.0"
                 || channel == "release/3.1"
-                || channel == "release/5.0")
+                || channel == "release/5.0"
+                ||
+                channel == "5.0" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // These scenarios are broken.
                 return;

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework.Assertions;
 using FluentAssertions;
 using System.Text.RegularExpressions;
 using System.Linq;
+using Install_Scripts.Test.Utils;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
@@ -19,16 +20,18 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         /// <summary>
         /// All the channels that will be tested.
         /// </summary>
-        private static readonly IReadOnlyList<(string channel, string versionRegex)> _channels =
-            new List<(string, string)>()
+        private static readonly IReadOnlyList<(string channel, string versionRegex, Quality quality)> _channels =
+            new List<(string, string, Quality)>()
             {
-                ("2.1", "2\\.1\\..*"),
-                ("2.2", "2\\.2\\..*"),
-                ("3.0", "3\\.0\\..*"),
-                ("3.1", "3\\.1\\..*"),
-                ("5.0", "5\\.0\\..*"),
-                ("Current", "5\\.0\\..*"),
-                ("LTS", "3\\.1\\..*"),
+                ("2.1", "2\\.1\\..*", Quality.None),
+                ("2.2", "2\\.2\\..*", Quality.None),
+                ("3.0", "3\\.0\\..*", Quality.None),
+                ("3.1", "3\\.1\\..*", Quality.None),
+                ("5.0", "5\\.0\\..*", Quality.None),
+                ("6.0-preview2", "6\\.0\\..*", Quality.All),
+                ("6.0", "6\\.0\\..*", Quality.Daily),
+                ("Current", "5\\.0\\..*", Quality.None),
+                ("LTS", "3\\.1\\..*", Quality.None),
             };
 
         /// <summary>
@@ -42,6 +45,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("release/3.0", "3\\.0\\..*"),
                 ("release/3.1", "3\\.1\\..*"),
                 ("release/5.0", "5\\.0\\..*"),
+                // branches are no longer supported starting 6.0
             };
 
         /// <summary>
@@ -56,7 +60,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("release/3.1.4xx", "3\\.1\\.4.*"),
                 ("release/5.0.1xx", "5\\.0\\.1.*"),
                 ("release/5.0.2xx", "5\\.0\\.2.*"),
-                ("master", "6\\.0\\.1.*"),
+                // branches are no longer supported starting 6.0
             };
 
         public static IEnumerable<object?[]> InstallSdkFromChannelTestCases
@@ -69,6 +73,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                     yield return new object?[]
                     {
                         sdkBranchInfo.branch,
+                        /*Quality:*/ null,
                         sdkBranchInfo.versionRegex,
                     };
                 }
@@ -76,11 +81,15 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // Download SDK from darc channels.
                 foreach (var channelInfo in _channels)
                 {
-                    yield return new object?[]
+                    foreach(string quality in GetQualityOptionsFromFlags(channelInfo.quality).DefaultIfEmpty())
                     {
-                        channelInfo.channel,
-                        channelInfo.versionRegex,
-                    };
+                        yield return new object?[]
+                        {
+                            channelInfo.channel,
+                            quality,
+                            channelInfo.versionRegex,
+                        };
+                    }
                 }
             }
         }
@@ -95,6 +104,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                     yield return new object?[]
                     {
                         runtimeBranchInfo.branch,
+                        /*Quality:*/ null,
                         runtimeBranchInfo.versionRegex,
                     };
                 }
@@ -102,11 +112,15 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // Download runtimes using darc channels.
                 foreach (var channelInfo in _channels)
                 {
-                    yield return new object?[]
+                    foreach (string quality in GetQualityOptionsFromFlags(channelInfo.quality).DefaultIfEmpty())
                     {
-                        channelInfo.channel,
-                        channelInfo.versionRegex,
-                    };
+                        yield return new object?[]
+                        {
+                            channelInfo.channel,
+                            quality,
+                            channelInfo.versionRegex,
+                        };
+                    }
                 }
             }
         }
@@ -124,8 +138,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         {
             _sdkInstallationDirectory = Path.Combine(
                 Path.GetTempPath(),
-                Path.GetRandomFileName(),
-                "InstallScript-Tests");
+                "InstallScript-Tests",
+                Path.GetRandomFileName());
 
             // In case there are any files from previous runs, clean them up.
             try
@@ -159,10 +173,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [MemberData(nameof(InstallSdkFromChannelTestCases))]
-        public void WhenInstallingTheSdk(string channel, string versionRegex)
+        public void WhenInstallingTheSdk(string channel, string? quality, string versionRegex)
         {
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, null, _sdkInstallationDirectory);
+            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -186,7 +200,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [MemberData(nameof(InstallRuntimeFromChannelTestCases))]
-        public void WhenInstallingDotnetRuntime(string channel, string versionRegex)
+        public void WhenInstallingDotnetRuntime(string channel, string? quality, string versionRegex)
         {
             if (channel == "release/5.0")
             {
@@ -195,7 +209,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             }
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "dotnet", _sdkInstallationDirectory);
+            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -220,7 +234,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [MemberData(nameof(InstallRuntimeFromChannelTestCases))]
-        public void WhenInstallingAspNetCoreRuntime(string channel, string versionRegex)
+        public void WhenInstallingAspNetCoreRuntime(string channel, string? quality, string versionRegex)
         {
             if (channel == "release/3.0"
                 || channel == "release/3.1"
@@ -229,9 +243,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // These scenarios are broken.
                 return;
             }
-            
+
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "aspnetcore", _sdkInstallationDirectory);
+            var args = GetInstallScriptArgs(channel, "aspnetcore", quality, _sdkInstallationDirectory);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -256,7 +270,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [MemberData(nameof(InstallRuntimeFromChannelTestCases))]
-        public void WhenInstallingWindowsdesktopRuntime(string channel, string versionRegex)
+        public void WhenInstallingWindowsdesktopRuntime(string channel, string? quality, string versionRegex)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -279,7 +293,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             }
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "windowsdesktop", _sdkInstallationDirectory);
+            var args = GetInstallScriptArgs(channel, "windowsdesktop", quality, _sdkInstallationDirectory);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -292,7 +306,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             // Add the validation once the becomes available in the artifacts.
         }
 
-        private static IEnumerable<string> GetInstallScriptArgs(string? channel, string? runtime, string? installDir)
+        private static IEnumerable<string> GetInstallScriptArgs(string? channel, string? runtime, string? quality, string? installDir)
         {
             if (!string.IsNullOrWhiteSpace(channel))
             {
@@ -310,6 +324,12 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             {
                 yield return "-Runtime";
                 yield return runtime;
+            }
+
+            if (!string.IsNullOrWhiteSpace(quality))
+            {
+                yield return "-Quality";
+                yield return quality;
             }
         }
 
@@ -358,6 +378,31 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 return null;
             }
             return directory;
+        }
+
+        private static IEnumerable<string> GetQualityOptionsFromFlags(Quality flags)
+        {
+            ulong flagsValue = (ulong)flags;
+
+            if(flagsValue == 0)
+            {
+                yield break;
+            }
+
+            foreach (Quality quality in Enum.GetValues(typeof(Quality)))
+            {
+                ulong qualityValue = (ulong)quality;
+                if(qualityValue == 0 || (qualityValue & (qualityValue-1)) != 0)
+                {
+                    // No bits are set, or more than one bits are set
+                    continue;
+                }
+
+                if ((flagsValue & qualityValue) != 0)
+                {
+                    yield return quality.ToString();
+                }
+            }
         }
     }
 }

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("release/2.1.8xx", "2\\.1\\.8.*", Quality.None),
                 ("release/2.2.4xx", "2\\.2\\.4.*", Quality.None),
                 ("release/3.0.1xx", "3\\.0\\.1.*", Quality.None),
-                ("release/3.1.4xx", "3\\.1\\.4.*", Quality.None),
+                // ("release/3.1.4xx", "3\\.1\\.4.*", Quality.None), Temporarily broken scenario
                 ("release/5.0.1xx", "5\\.0\\.1.*", Quality.None),
                 ("release/5.0.2xx", "5\\.0\\.2.*", Quality.None),
                 // Branches are no longer supported starting 6.0, but there are channels that correspond to branches.
@@ -209,7 +209,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [MemberData(nameof(InstallRuntimeFromChannelTestCases))]
         public void WhenInstallingDotnetRuntime(string channel, string? quality, string versionRegex)
         {
-            if (channel == "release/5.0")
+            if (channel == "release/5.0" ||
+                channel == "5.0" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Broken scenario
                 return;
@@ -287,10 +288,12 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             List<Regex> exclusions = new List<Regex>()
             {
-                new Regex(".*2\\..*"), // Runtime is not supported in this version.
-                new Regex(".*3\\.0.*"), // Runtime is not supported in this version.
-                new Regex("release/3.1"), // Broken scenario.
-                new Regex("release/5.0"), // Broken scenario.
+                new Regex(".*2\\..*"),     // Runtime is not supported in this version.
+                new Regex(".*3\\.0.*"),    // Runtime is not supported in this version.
+                new Regex("release/3.1"),  // Broken scenario.
+                new Regex("release/5.0"),  // Broken scenario.
+                new Regex("6.0"),          // Broken scenario.
+                new Regex("6.0-preview2"), // Broken scenario.
             };
 
             if (exclusions.Any(e => e.IsMatch(channel)))

--- a/tests/Install-Scripts.Test/TestBase.cs
+++ b/tests/Install-Scripts.Test/TestBase.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.InstallationScript.Tests
+{
+    public abstract class TestBase
+    {
+        protected static Command CreateInstallCommand(IEnumerable<string> args)
+        {
+            string path;
+            string finalArgs;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                path = "powershell.exe";
+                finalArgs = "-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"" +
+                    Path.Combine(GetRepoRoot(), "src", "dotnet-install.ps1") + " " + ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args) + "\"";
+            }
+            else
+            {
+                path = Path.Combine(GetRepoRoot(), "src", "dotnet-install.sh");
+                finalArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
+            }
+
+            return Command.Create(new CommandSpec(path, finalArgs, CommandResolutionStrategy.None));
+        }
+
+        protected static string GetRepoRoot()
+        {
+            string directory = AppContext.BaseDirectory;
+
+            while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
+            {
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            if (directory == null)
+            {
+                return null;
+            }
+            return directory;
+        }
+    }
+}

--- a/tests/Install-Scripts.Test/Utils/Quality.cs
+++ b/tests/Install-Scripts.Test/Utils/Quality.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Install_Scripts.Test.Utils
+{
+    [Flags]
+    enum Quality
+    {
+        None = 0,
+        Daily = 1,
+        Signed = 2,
+        Validated = 4,
+        Preview = 8,
+        Ga = 16,
+        All = Daily | Signed | Validated | Preview | Ga,
+    }
+}


### PR DESCRIPTION
fixes https://github.com/dotnet/install-scripts/issues/12

Added the resolution of download link via aka.ms links as primary method; the current implementation is kept as the fallback
Added the support for specifying the quality for build in certain channel (supported with aka.ms links only for 5.0+ versions)

Added unit and integration tests.


