### PR TITLE
fixes dotnet/install-scripts#13: use of --runtime-id generates incorrect primary URL for linux-musl-x64

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -183,6 +183,9 @@ get_current_os_name() {
         elif is_musl_based_distro; then
             echo "linux-musl"
             return 0
+        elif [ "$linux_platform_name" = "linux-musl" ]; then
+            echo "linux-musl"
+            return 0
         else
             echo "linux"
             return 0


### PR DESCRIPTION
dotnet/install-scripts#13:
Part 1: use of --runtime-id generates incorrect primary URL for linux-musl-x64