### PR TITLE
Powershell: changed the location of windows desktop runtime starting 5.0

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -437,21 +437,15 @@ function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string
         $PayloadURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/aspnetcore-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
     }
     elseif ($Runtime -eq "windowsdesktop") {
+        # The windows desktop runtime is part of the core runtime layout prior to 5.0
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
         if ($SpecificVersion -match '^(\d+)\.(.*)$')
         {
             $majorVersion = [int]$Matches[1]
-            if ($majorVersion -lt 5)
-            {
-                $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
-            }
-            else
+            if ($majorVersion -ge 5)
             {
                 $PayloadURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
             }
-        }
-        else
-        {
-            $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
         }
     }
     elseif (-not $Runtime) {
@@ -494,21 +488,15 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion) {
         $ProductVersionTxtURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/productVersion.txt"
     }
     elseif ($Runtime -eq "windowsdesktop") {
+        # The windows desktop runtime is part of the core runtime layout prior to 5.0
+        $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
         if ($SpecificVersion -match '^(\d+)\.(.*)')
         {
             $majorVersion = [int]$Matches[1]
-            if ($majorVersion -lt 5)
-            {
-                $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
-            }
-            else
+            if ($majorVersion -ge 5)
             {
                 $ProductVersionTxtURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/productVersion.txt"
             }
-        }
-        else
-        {
-            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
         }
     }
     elseif (-not $Runtime) {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -439,7 +439,7 @@ function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string
     elseif ($Runtime -eq "windowsdesktop") {
         if ($SpecificVersion -match '^(\d+)\.(.*)$')
         {
-            $majorVersion = [int]$Matches[1];
+            $majorVersion = [int]$Matches[1]
             if ($majorVersion -lt 5)
             {
                 $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
@@ -496,7 +496,7 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion) {
     elseif ($Runtime -eq "windowsdesktop") {
         if ($SpecificVersion -match '^(\d+)\.(.*)')
         {
-            $majorVersion = [int]$Matches[1];
+            $majorVersion = [int]$Matches[1]
             if ($majorVersion -lt 5)
             {
                 $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -340,9 +340,8 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel) {
     elseif ($Runtime -eq "aspnetcore") {
         $VersionFileUrl = "$UncachedFeed/aspnetcore/Runtime/$Channel/latest.version"
     }
-    # Currently, the WindowsDesktop runtime is manufactured with the .Net core runtime
     elseif ($Runtime -eq "windowsdesktop") {
-        $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.version"
+        $VersionFileUrl = "$UncachedFeed/WindowsDesktop/$Channel/latest.version"
     }
     elseif (-not $Runtime) {
         $VersionFileUrl = "$UncachedFeed/Sdk/$Channel/latest.version"
@@ -438,7 +437,22 @@ function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string
         $PayloadURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/aspnetcore-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
     }
     elseif ($Runtime -eq "windowsdesktop") {
-        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+        if ($SpecificVersion -match '^(\d+)\.(.*)$')
+        {
+            $majorVersion = [int]$Matches[1];
+            if ($majorVersion -lt 5)
+            {
+                $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+            }
+            else
+            {
+                $PayloadURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+            }
+        }
+        else
+        {
+            $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+        }
     }
     elseif (-not $Runtime) {
         $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-sdk-$SpecificProductVersion-win-$CLIArchitecture.zip"
@@ -480,7 +494,22 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion) {
         $ProductVersionTxtURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/productVersion.txt"
     }
     elseif ($Runtime -eq "windowsdesktop") {
-        $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
+        if ($SpecificVersion -match '^(\d+)\.(.*)')
+        {
+            $majorVersion = [int]$Matches[1];
+            if ($majorVersion -lt 5)
+            {
+                $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
+            }
+            else
+            {
+                $ProductVersionTxtURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/productVersion.txt"
+            }
+        }
+        else
+        {
+            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/productVersion.txt"
+        }
     }
     elseif (-not $Runtime) {
         $ProductVersionTxtURL = "$AzureFeed/Sdk/$SpecificVersion/productVersion.txt"

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallTheSdkFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallTheSdkFromAScript.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("2.2", "dotnet")]
         [InlineData("3.0", "dotnet")]
         [InlineData("3.1", "dotnet")]
-        // [InlineData("5.0", "dotnet")] - Broken
+        [InlineData("5.0", "dotnet")]
         [InlineData("Current", "dotnet")]
         [InlineData("LTS", "dotnet")]
         [InlineData("master", "dotnet")]
@@ -109,14 +109,32 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         // [InlineData("release/5.0", "dotnet")] - Broken
         [InlineData("Current", "aspnetcore")]
         [InlineData("LTS", "aspnetcore")]
+        //[InlineData("1.0", "aspnetcore")] - Broken
+        //[InlineData("1.1", "aspnetcore")] - Broken
+        //[InlineData("2.0", "aspnetcore")] - Broken
+        [InlineData("2.2", "aspnetcore")]
+        [InlineData("3.0", "aspnetcore")]
+        [InlineData("3.1", "aspnetcore")]
+        [InlineData("5.0", "aspnetcore")]
         [InlineData("master", "aspnetcore")]
         [InlineData("release/2.1", "aspnetcore")]
         [InlineData("release/2.2", "aspnetcore")]
-        // [InlineData("release/3.0", "aspnetcore")] - Broken
-        // [InlineData("release/3.1", "aspnetcore")] - Broken
-        // [InlineData("release/5.0", "aspnetcore")] - Broken
+        //[InlineData("release/3.0", "aspnetcore")] - Broken
+        //[InlineData("release/3.1", "aspnetcore")] - Broken
+        //[InlineData("release/5.0", "aspnetcore")] - Broken 
+        [InlineData("Current", "windowsdesktop")]
+        [InlineData("LTS", "windowsdesktop")]
+        [InlineData("3.0", "windowsdesktop")]
+        [InlineData("3.1", "windowsdesktop")]
+        [InlineData("5.0", "windowsdesktop")]
+        [InlineData("master", "windowsdesktop")]
         public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtimeType == "windowsdesktop")
+            {
+                //do not run windowsdesktop test on Linux environment
+                return;
+            }
             var args = new string[] { "-dryrun", "-channel", channel, "-runtime", runtimeType };
 
             var commandResult = CreateInstallCommand(args)
@@ -188,6 +206,26 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             //  Channel should be translated to a specific SDK version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
         }
+
+        [Theory]
+        [InlineData("5.0.1", "WindowsDesktop")]
+        [InlineData("3.1.10", "Runtime")]
+        public void CanResolveCorrectLocationBasedOnVersion(string version, string location)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //do not run windowsdesktop test on Linux environment
+                return;
+            }
+            string expectedLinkLog = $"Constructed primary named payload URL: {Environment.NewLine}https://dotnetcli.azureedge.net/dotnet/{location}/{version}";
+            var args = new string[] { "-version", version, "-runtime", "windowsdesktop", "-verbose", "-dryrun"};
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass().And.HaveStdOutContaining(expectedLinkLog);
+        } 
 
         private static Command CreateInstallCommand(IEnumerable<string> args)
         {


### PR DESCRIPTION
fixes https://github.com/dotnet/install-scripts/issues/116 and https://github.com/dotnet/install-scripts/issues/105#issuecomment-730428570 

Starting 5.0, use `<feed location>/WindowsDesktop` for `windowsdesktop` runtime. 