### PR TITLE
Support macos-arm64

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -303,7 +303,7 @@ get_machine_architecture() {
             echo "arm"
             return 0
             ;;
-        aarch64)
+        aarch64|arm64)
             echo "arm64"
             return 0
             ;;


### PR DESCRIPTION
On macos-arm64 `uname -m` returns `arm64`.  Update `get_machine_architecture()`