### PR TITLE
Harden tput command against unset TERM

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -24,7 +24,7 @@ exec 3>&1
 # See if stdout is a terminal
 if [ -t 1 ] && command -v tput > /dev/null; then
     # see if it supports colors
-    ncolors=$(tput colors)
+    ncolors=$(tput colors || echo 0)
     if [ -n "$ncolors" ] && [ $ncolors -ge 8 ]; then
         bold="$(tput bold       || echo)"
         normal="$(tput sgr0     || echo)"


### PR DESCRIPTION
This was reported in https://github.com/dotnet/install-scripts/issues/125 and I just had another report of this in a different context.
There's no reason why we should fail to install dotnet just because we couldn't get the colors, so harden against `tput` failing.