### PR TITLE
Add internal switch

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -249,7 +249,7 @@ function Get-NormalizedChannel([string]$Channel) {
     }
 
     if ($Channel -eq "lts" -or $Channel -eq "current" -or $Channel.StartsWith('release/')) {
-        Say-Warning "Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead."
+        Say-Warning 'Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead, such as "-Channel 5.0 -Quality Daily."'
     }
 
     switch ($Channel) {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -33,7 +33,10 @@
     - 3-part version in a format A.B.C - represents specific version of build
           examples: 2.0.0-preview2-006120, 1.1.0
 .PARAMETER Internal
-    Set this switch to download internal builds. It is necessary to use FeedCredential option with this.
+    Download internal builds. Provide credentials via -FeedCredential parameter.
+.PARAMETER FeedCredential
+    Used as a query string to append to the Azure feed.
+    It allows changing the URL to use non-public blob storage accounts.
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
@@ -68,9 +71,6 @@
 .PARAMETER UncachedFeed
     This parameter typically is not changed by the user.
     It allows changing the URL for the Uncached feed used by this installer.
-.PARAMETER FeedCredential
-    Used as a query string to append to the Azure feed.
-    It allows changing the URL to use non-public blob storage accounts.
 .PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
 .PARAMETER ProxyUseDefaultCredentials
@@ -896,7 +896,11 @@ Say "- The SDK installation doesn't need to persist across multiple CI runs."
 Say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
 
 if ($Internal -and [string]::IsNullOrEmpty($FeedCredential)) {
-    Say-Warning "Note, it is necessary to use FeedCredential option when Internal switch is set."
+    if ($DryRun) {
+        Say-Warning "Provide credentials via -FeedCredential parameter."
+    } else {
+        throw "Provide credentials via -FeedCredential parameter."
+    }
 }
 
 #FeedCredential should start with "?", for it to be added to the end of the link.

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -986,10 +986,6 @@ if ($DryRun) {
         $RepeatableCommand+=" -Quality `"$NormalizedQuality`""
     }
 
-    if ($Internal) {
-        $RepeatableCommand+=" -Internal"
-    }
-
     foreach ($key in $MyInvocation.BoundParameters.Keys) {
         if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality","FeedCredential") -contains $key)) {
             $RepeatableCommand+=" -$key `"$($MyInvocation.BoundParameters[$key])`""

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -125,12 +125,6 @@ if ($SharedRuntime -and (-not $Runtime)) {
     $Runtime = "dotnet"
 }
 
-#FeedCredential should start with "?", for it to be added to the end of the link.
-#adding "?" at the beginning of the FeedCredential if needed.
-if ((![string]::IsNullOrEmpty($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
-    $FeedCredential = "?" + $FeedCredential
-}
-
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles = !$SkipNonVersionedFiles
@@ -900,6 +894,16 @@ Say "Note that the intended use of this script is for Continuous Integration (CI
 Say "- The SDK needs to be installed without user interaction and without admin rights."
 Say "- The SDK installation doesn't need to persist across multiple CI runs."
 Say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
+
+if ($Internal -and [string]::IsNullOrEmpty($FeedCredential)) {
+    Say-Warning "Note, it is necessary to use FeedCredential option when Internal switch is set."
+}
+
+#FeedCredential should start with "?", for it to be added to the end of the link.
+#adding "?" at the beginning of the FeedCredential if needed.
+if ((![string]::IsNullOrEmpty($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
+    $FeedCredential = "?" + $FeedCredential
+}
 
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
 $NormalizedQuality = Get-NormalizedQuality $Quality

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -895,11 +895,13 @@ Say "- The SDK needs to be installed without user interaction and without admin 
 Say "- The SDK installation doesn't need to persist across multiple CI runs."
 Say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
 
+$FeedCredential = $FeedCredential.Trim();
 if ($Internal -and [string]::IsNullOrEmpty($FeedCredential)) {
+    $message = "Provide credentials via -FeedCredential parameter."
     if ($DryRun) {
-        Say-Warning "Provide credentials via -FeedCredential parameter."
+        Say-Warning "$message"
     } else {
-        throw "Provide credentials via -FeedCredential parameter."
+        throw "$message"
     }
 }
 

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -125,6 +125,12 @@ if ($SharedRuntime -and (-not $Runtime)) {
     $Runtime = "dotnet"
 }
 
+#FeedCredential should start with "?", for it to be added to the end of the link.
+#adding "?" at the beginning of the FeedCredential if needed.
+if ($FeedCredential[0] -ne '?') {
+    $FeedCredential = "?" + $FeedCredential
+}
+
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles = !$SkipNonVersionedFiles

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -959,9 +959,9 @@ $ScriptName = $MyInvocation.MyCommand.Name
 
 if ($DryRun) {
     Say "Payload URLs:"
-    Say "Primary named payload URL: $DownloadLink"
+    Say "Primary named payload URL: ${DownloadLink}${FeedCredential}"
     if ($LegacyDownloadLink) {
-        Say "Legacy named payload URL: $LegacyDownloadLink"
+        Say "Legacy named payload URL: ${LegacyDownloadLink}${FeedCredential}"
     }
     $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
     if ($Runtime -eq "dotnet") {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -859,6 +859,9 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
     Say-Verbose  "Constructed aka.ms link: '$akaMsLink'."
 
     #get HTTP response
+    #do not pass credentials as a part of the $akaMsLink and do not apply credentials in the GetHTTPResponse function
+    #otherwise the redirect link would have credentials as well
+    #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
     $Response= GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true -DisableFeedCredential $true
     Say-Verbose "Received response:`n$Response"
 

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -970,6 +970,9 @@ if ($DryRun) {
         $RepeatableCommand+=" -Quality `"$NormalizedQuality`""
     }
 
+    if ($Internal) {
+        $RepeatableCommand+=" -Internal"
+    }
 
     foreach ($key in $MyInvocation.BoundParameters.Keys) {
         if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality") -contains $key)) {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -33,7 +33,7 @@
     - 3-part version in a format A.B.C - represents specific version of build
           examples: 2.0.0-preview2-006120, 1.1.0
 .PARAMETER Internal
-    Set this parameter to access internal builds. It might be nessesary also to use FeedCredential parameter with it.
+    Set this switch to download internal builds. It is necessary to use FeedCredential option with this.
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -32,6 +32,8 @@
     - latest - most latest build on specific channel
     - 3-part version in a format A.B.C - represents specific version of build
           examples: 2.0.0-preview2-006120, 1.1.0
+.PARAMETER Internal
+    Set this parameter to access internal builds. It might be nessesary also to use FeedCredential parameter with it.
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
@@ -90,6 +92,7 @@ param(
    [string]$Channel="LTS",
    [string]$Quality,
    [string]$Version="Latest",
+   [switch]$Internal,
    [string]$JSonFile,
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
@@ -837,11 +840,14 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
     Say-Verbose "Retrieving primary payload URL from aka.ms link for channel: '$Channel', quality: '$Quality' product: '$Product', os: 'win', architecture: '$Architecture'." 
    
     #construct aka.ms link
-    $akaMsLink = "https://aka.ms/dotnet/$Channel" 
+    $akaMsLink = "https://aka.ms/dotnet"
+    if ($Internal) {
+        $akaMsLink += "/internal"
+    }
+    $akaMsLink += "/$Channel"
     if (-not [string]::IsNullOrEmpty($Quality)) {
         $akaMsLink +="/$Quality"
     }
-
     $akaMsLink +="/$Product-win-$Architecture.zip"
     Say-Verbose  "Constructed aka.ms link: '$akaMsLink'."
 
@@ -937,6 +943,7 @@ Say-Verbose "InstallRoot: $InstallRoot"
 $ScriptName = $MyInvocation.MyCommand.Name
 
 if ($DryRun) {
+    Say "aka.ms link: $AkaMsDownloadLink"
     Say "Payload URLs:"
     Say "Primary named payload URL: $DownloadLink"
     if ($LegacyDownloadLink) {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -969,9 +969,9 @@ $ScriptName = $MyInvocation.MyCommand.Name
 
 if ($DryRun) {
     Say "Payload URLs:"
-    Say "Primary named payload URL: ${DownloadLink}${FeedCredential}"
+    Say "Primary named payload URL: ${DownloadLink}"
     if ($LegacyDownloadLink) {
-        Say "Legacy named payload URL: ${LegacyDownloadLink}${FeedCredential}"
+        Say "Legacy named payload URL: ${LegacyDownloadLink}"
     }
     $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
     if ($Runtime -eq "dotnet") {
@@ -991,8 +991,11 @@ if ($DryRun) {
     }
 
     foreach ($key in $MyInvocation.BoundParameters.Keys) {
-        if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality") -contains $key)) {
+        if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality","FeedCredential") -contains $key)) {
             $RepeatableCommand+=" -$key `"$($MyInvocation.BoundParameters[$key])`""
+        }
+        if ($key -eq "FeedCredential") {
+            $RepeatableCommand+=" -$key `"<feedCredential>`""
         }
     }
     Say "Repeatable invocation: $RepeatableCommand"

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -853,7 +853,6 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
 
     #get HTTP response
     $Response= GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true
-    Say-Verbose "Received response:`n$Response"
 
     if ([string]::IsNullOrEmpty($Response)) {
         Say-Verbose "The aka.ms link '$akaMsLink' is not valid: failed to get redirect location. The resource is not available."
@@ -865,6 +864,9 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
     {
         try {
             $akaMsDownloadLink = $Response.Headers.GetValues("Location")[0]
+            #FeedCredential is the part of redirect link, remove it
+            $akaMsDownloadLink = $akaMsDownloadLink.split('?')[0]
+
             if ([string]::IsNullOrEmpty($akaMsDownloadLink)) {
                 Say-Verbose "The aka.ms link '$akaMsLink' is not valid: failed to get redirect location."
                 return $null

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -33,10 +33,10 @@
     - 3-part version in a format A.B.C - represents specific version of build
           examples: 2.0.0-preview2-006120, 1.1.0
 .PARAMETER Internal
-    Download internal builds. Provide credentials via -FeedCredential parameter.
+    Download internal builds. Requires providing credentials via -FeedCredential parameter.
 .PARAMETER FeedCredential
-    Used as a query string to append to the Azure feed.
-    It allows changing the URL to use non-public blob storage accounts.
+    Token to access Azure feed. Used as a query string to append to the Azure feed.
+    It allows changing the URL to use non-public blob storage accounts. This parameter typically is not specified.
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
@@ -895,8 +895,7 @@ Say "- The SDK needs to be installed without user interaction and without admin 
 Say "- The SDK installation doesn't need to persist across multiple CI runs."
 Say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
 
-$FeedCredential = $FeedCredential.Trim();
-if ($Internal -and [string]::IsNullOrEmpty($FeedCredential)) {
+if ($Internal -and [string]::IsNullOrWhitespace($FeedCredential)) {
     $message = "Provide credentials via -FeedCredential parameter."
     if ($DryRun) {
         Say-Warning "$message"
@@ -907,7 +906,7 @@ if ($Internal -and [string]::IsNullOrEmpty($FeedCredential)) {
 
 #FeedCredential should start with "?", for it to be added to the end of the link.
 #adding "?" at the beginning of the FeedCredential if needed.
-if ((![string]::IsNullOrEmpty($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
+if ((![string]::IsNullOrWhitespace($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
     $FeedCredential = "?" + $FeedCredential
 }
 
@@ -990,9 +989,9 @@ if ($DryRun) {
         if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality","FeedCredential") -contains $key)) {
             $RepeatableCommand+=" -$key `"$($MyInvocation.BoundParameters[$key])`""
         }
-        if ($key -eq "FeedCredential") {
-            $RepeatableCommand+=" -$key `"<feedCredential>`""
-        }
+    }
+    if ($MyInvocation.BoundParameters.Keys -contains "FeedCredential") {
+        $RepeatableCommand+=" -FeedCredential `"<feedCredential>`""
     }
     Say "Repeatable invocation: $RepeatableCommand"
     if ($SpecificVersion -ne $EffectiveVersion)

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -951,7 +951,6 @@ Say-Verbose "InstallRoot: $InstallRoot"
 $ScriptName = $MyInvocation.MyCommand.Name
 
 if ($DryRun) {
-    Say "aka.ms link: $AkaMsDownloadLink"
     Say "Payload URLs:"
     Say "Primary named payload URL: $DownloadLink"
     if ($LegacyDownloadLink) {

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -127,7 +127,7 @@ if ($SharedRuntime -and (-not $Runtime)) {
 
 #FeedCredential should start with "?", for it to be added to the end of the link.
 #adding "?" at the beginning of the FeedCredential if needed.
-if ($FeedCredential[0] -ne '?') {
+if ((![string]::IsNullOrEmpty($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
     $FeedCredential = "?" + $FeedCredential
 }
 
@@ -870,13 +870,15 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [string]$Prod
     {
         try {
             $akaMsDownloadLink = $Response.Headers.GetValues("Location")[0]
-            #FeedCredential is the part of redirect link, remove it
-            $akaMsDownloadLink = $akaMsDownloadLink.split('?')[0]
 
             if ([string]::IsNullOrEmpty($akaMsDownloadLink)) {
                 Say-Verbose "The aka.ms link '$akaMsLink' is not valid: failed to get redirect location."
                 return $null
             }
+
+            #FeedCredential is the part of redirect link, remove it
+            $akaMsDownloadLink = $akaMsDownloadLink.split('?')[0]
+
             Say-Verbose "The redirect location retrieved: '$akaMsDownloadLink'."
             return $akaMsDownloadLink
         }

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1048,12 +1048,15 @@ get_download_link_from_aka_ms() {
     #if HTTP code is 301 (Moved Permanently), the redirect link exists
     if [[ "$http_code" == "301" ]]; then
         aka_ms_download_link=$( echo "$response" | awk '$1 ~ /^Location/{print $2}' | head -1 | tr -d '\r')
-        #feed_credential is the part of redirect link, remove it
-        aka_ms_download_link=$( echo "${aka_ms_download_link%%\?*}" )
+
         if [[ -z "$aka_ms_download_link" ]]; then
             say_verbose "The aka.ms link '$aka_ms_link' is not valid: failed to get redirect location."
             return 1
         fi
+
+        #feed_credential is the part of redirect link, remove it
+        aka_ms_download_link=$( echo "${aka_ms_download_link%%\?*}" )
+
         say_verbose "The redirect location retrieved: '$aka_ms_download_link'."
         return 0
     else

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1481,6 +1481,10 @@ say "- The SDK needs to be installed without user interaction and without admin 
 say "- The SDK installation doesn't need to persist across multiple CI runs."
 say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
 
+if [ "$internal" = true ] && [ -z "$feed_credential" ]; then
+    say_warning "Note, it is necessary to use --feed-credential option when --internal switch is set."
+fi
+
 check_min_reqs
 calculate_vars
 script_name=$(basename "$0")

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1419,7 +1419,8 @@ do
             echo "          For SDK use channel in A.B.Cxx format. Using quality for SDK together with channel in A.B format is not supported." 
             echo "          Supported since 5.0 release." 
             echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used, and therefore overrides the quality."
-            echo "  --internal,-Internal               Set this switch to download internal builds. It is necessary to use --feed-credential option with this."
+            echo "  --internal,-Internal               Download internal builds. Provide credentials via --feed-credential parameter."
+            echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
             echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
@@ -1440,7 +1441,6 @@ do
             echo "  --verbose,-Verbose                 Display diagnostics information."
             echo "  --azure-feed,-AzureFeed            Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
             echo "  --uncached-feed,-UncachedFeed      Uncached feed location. This parameter typically is not changed by the user."
-            echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
             echo "  --skip-non-versioned-files         Skips non-versioned files if they already exist, such as the dotnet executable."
             echo "      -SkipNonVersionedFiles"
             echo "  --no-cdn,-NoCdn                    Disable downloading from the Azure CDN, and use the uncached feed directly."
@@ -1482,7 +1482,12 @@ say "- The SDK installation doesn't need to persist across multiple CI runs."
 say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
 
 if [ "$internal" = true ] && [ -z "$feed_credential" ]; then
-    say_warning "Note, it is necessary to use --feed-credential option when --internal switch is set."
+    if [ "$dry_run" = true ]; then
+        say_warning "Provide credentials via --feed-credential parameter."
+    else
+        say_err "Provide credentials via --feed-credential parameter."
+        exit 1
+    fi
 fi
 
 check_min_reqs

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1043,12 +1043,13 @@ get_download_link_from_aka_ms() {
     #get HTTP response
     response="$(get_http_header "$aka_ms_link")"
 
-    say_verbose "Received response: $response"
     http_code=$( echo "$response" | awk '$1 ~ /^HTTP/ {print $2}' | head -1 )
 
     #if HTTP code is 301 (Moved Permanently), the redirect link exists
     if [[ "$http_code" == "301" ]]; then
         aka_ms_download_link=$( echo "$response" | awk '$1 ~ /^Location/{print $2}' | head -1 | tr -d '\r')
+        #feed_credential is the part of redirect link, remove it
+        aka_ms_download_link=$( echo "${aka_ms_download_link%%\?*}" )
         if [[ -z "$aka_ms_download_link" ]]; then
             say_verbose "The aka.ms link '$aka_ms_link' is not valid: failed to get redirect location."
             return 1

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1029,7 +1029,11 @@ get_download_link_from_aka_ms() {
     say_verbose "Retrieving primary payload URL from aka.ms for channel: '$normalized_channel', quality: '$normalized_quality', product: '$normalized_product', os: '$normalized_os', architecture: '$normalized_architecture'." 
 
     #construct aka.ms link
-    aka_ms_link="https://aka.ms/dotnet/$normalized_channel" 
+    aka_ms_link="https://aka.ms/dotnet"
+    if  [ "$internal" = true ]; then
+        aka_ms_link="$aka_ms_link/internal"
+    fi
+    aka_ms_link="$aka_ms_link/$normalized_channel"
     if [[ ! -z "$normalized_quality" ]]; then
         aka_ms_link="$aka_ms_link/$normalized_quality"
     fi
@@ -1282,6 +1286,7 @@ verbose=false
 runtime=""
 runtime_id=""
 quality=""
+internal=false
 override_non_versioned_files=true
 non_dynamic_parameters=""
 user_defined_os=""
@@ -1301,6 +1306,9 @@ do
         -q|--quality|-[Qq]uality)
             shift
             quality="$1"
+            ;;
+        --internal|-[Ii]nternal)
+            internal=true
             ;;
         -i|--install-dir|-[Ii]nstall[Dd]ir)
             shift

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1328,6 +1328,7 @@ do
             ;;
         --internal|-[Ii]nternal)
             internal=true
+            non_dynamic_parameters+=" $name"
             ;;
         -i|--install-dir|-[Ii]nstall[Dd]ir)
             shift
@@ -1526,9 +1527,6 @@ if [ "$dry_run" = true ]; then
         repeatable_command+=" --quality "\""$normalized_quality"\"""
     fi
 
-    if [ "$internal" = true ]; then
-        repeatable_command+=" --internal"
-    fi
 
     if [[ "$runtime" == "dotnet" ]]; then
         repeatable_command+=" --runtime "\""dotnet"\"""
@@ -1539,7 +1537,7 @@ if [ "$dry_run" = true ]; then
     repeatable_command+="$non_dynamic_parameters"
 
     if [ ! -z "$feed_credential" ]; then
-        repeatable_command+=" --feed-credential "\""<feed-credential>"\"""
+        repeatable_command+=" --feed-credential "\""<feed_credential>"\"""
     fi
 
     say "Repeatable invocation: $repeatable_command"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1367,9 +1367,10 @@ do
         --feed-credential|-[Ff]eed[Cc]redential)
             shift
             feed_credential="$1"
+            feed_credential=$(echo $feed_credential)
             #feed_credential should start with "?", for it to be added to the end of the link.
             #adding "?" at the beginning of the feed_credential if needed.
-            [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
+            [[ -z "$feed_credential" ]] || [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
             non_dynamic_parameters+=" $name "\""$1"\"""
             ;;
         --runtime-id|-[Rr]untime[Ii]d)
@@ -1482,10 +1483,11 @@ say "- The SDK installation doesn't need to persist across multiple CI runs."
 say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
 
 if [ "$internal" = true ] && [ -z "$feed_credential" ]; then
+    message="Provide credentials via --feed-credential parameter."
     if [ "$dry_run" = true ]; then
-        say_warning "Provide credentials via --feed-credential parameter."
+        say_warning "$message"
     else
-        say_err "Provide credentials via --feed-credential parameter."
+        say_err "$message"
         exit 1
     fi
 fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1368,6 +1368,9 @@ do
         --feed-credential|-[Ff]eed[Cc]redential)
             shift
             feed_credential="$1"
+            #feed_credential should start with "?", for it to be added to the end of the link.
+            #adding "?" at the beginning of the feed_credential if needed.
+            [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
             non_dynamic_parameters+=" $name "\""$1"\"""
             ;;
         --runtime-id|-[Rr]untime[Ii]d)

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -880,9 +880,9 @@ get_http_header()
     local failed=false
     local response
     if machine_has "curl"; then
-        get_http_header_curl $remote_path "$disable_feed_credential" || failed=true
+        get_http_header_curl $remote_path $disable_feed_credential || failed=true
     elif machine_has "wget"; then
-        get_http_header_wget $remote_path "$disable_feed_credential" || failed=true
+        get_http_header_wget $remote_path $disable_feed_credential || failed=true
     else
         failed=true
     fi
@@ -1387,10 +1387,9 @@ do
         --feed-credential|-[Ff]eed[Cc]redential)
             shift
             feed_credential="$1"
-            feed_credential=$(echo $feed_credential)
             #feed_credential should start with "?", for it to be added to the end of the link.
             #adding "?" at the beginning of the feed_credential if needed.
-            [[ -z "$feed_credential" ]] || [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
+            [[ -z "$(echo $feed_credential)" ]] || [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
             ;;
         --runtime-id|-[Rr]untime[Ii]d)
             shift
@@ -1439,8 +1438,9 @@ do
             echo "          For SDK use channel in A.B.Cxx format. Using quality for SDK together with channel in A.B format is not supported." 
             echo "          Supported since 5.0 release." 
             echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used, and therefore overrides the quality."
-            echo "  --internal,-Internal               Download internal builds. Provide credentials via --feed-credential parameter."
-            echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
+            echo "  --internal,-Internal               Download internal builds. Requires providing credentials via --feed-credential parameter."
+            echo "  --feed-credential <FEEDCREDENTIAL> Token to access Azure feed. Used as a query string to append to the Azure feed."
+            echo "      -FeedCredential                It allows changing the URL to use non-public blob storage accounts. This parameter typically is not specified."
             echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
@@ -1501,7 +1501,7 @@ say "- The SDK needs to be installed without user interaction and without admin 
 say "- The SDK installation doesn't need to persist across multiple CI runs."
 say "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
 
-if [ "$internal" = true ] && [ -z "$feed_credential" ]; then
+if [ "$internal" = true ] && [ -z "$(echo $feed_credential)" ]; then
     message="Provide credentials via --feed-credential parameter."
     if [ "$dry_run" = true ]; then
         say_warning "$message"
@@ -1536,7 +1536,7 @@ if [ "$dry_run" = true ]; then
 
     repeatable_command+="$non_dynamic_parameters"
 
-    if [ ! -z "$feed_credential" ]; then
+    if [ -n "$feed_credential" ]; then
         repeatable_command+=" --feed-credential "\""<feed_credential>"\"""
     fi
 

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -729,7 +729,7 @@ get_product_specific_version_from_download_link()
     IFS='-'
     read -ra filename_elems <<< "$filename"
     count=${#filename_elems[@]}
-    if ["$count" -gt 2]; then
+    if [[ "$count" -gt 2 ]]; then
         specific_product_version="${filename_elems[2]}"
     else
         specific_product_version=$specific_version

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -973,7 +973,7 @@ downloadcurl() {
         curl $curl_options -o "$out_path" "$remote_path_with_credential" || failed=true
     fi
     if [ "$failed" = true ]; then
-        local response=$(get_http_header_curl $remote_path_with_credential)
+        local response=$(get_http_header_curl $remote_path)
         http_code=$( echo "$response" | awk '/^HTTP/{print $2}' | tail -1 )
         download_error_msg="Unable to download $remote_path."
         if  [[ $http_code != 2* ]]; then
@@ -1371,7 +1371,6 @@ do
             #feed_credential should start with "?", for it to be added to the end of the link.
             #adding "?" at the beginning of the feed_credential if needed.
             [[ -z "$feed_credential" ]] || [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
-            non_dynamic_parameters+=" $name "\""$1"\"""
             ;;
         --runtime-id|-[Rr]untime[Ii]d)
             shift
@@ -1498,9 +1497,9 @@ script_name=$(basename "$0")
 
 if [ "$dry_run" = true ]; then
     say "Payload URLs:"
-    say "Primary named payload URL: ${download_link}${feed_credential}"
+    say "Primary named payload URL: ${download_link}"
     if [ "$valid_legacy_download_link" = true ]; then
-        say "Legacy named payload URL: ${legacy_download_link}${feed_credential}"
+        say "Legacy named payload URL: ${legacy_download_link}"
     fi
     repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"" --os "\""$normalized_os"\"""
     
@@ -1517,7 +1516,13 @@ if [ "$dry_run" = true ]; then
     elif [[ "$runtime" == "aspnetcore" ]]; then
         repeatable_command+=" --runtime "\""aspnetcore"\"""
     fi
+
     repeatable_command+="$non_dynamic_parameters"
+
+    if [ ! -z "$feed_credential" ]; then
+        repeatable_command+=" --feed-credential "\""<feed-credential>"\"""
+    fi
+
     say "Repeatable invocation: $repeatable_command"
     exit 0
 fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -983,6 +983,7 @@ downloadcurl() {
     local remote_path="$1"
     local out_path="${2:-}"
     # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
+    # Avoid passing URI with credentials to functions: note, most of them echoing parameters of invocation in verbose output.
     local remote_path_with_credential="${remote_path}${feed_credential}"
     local curl_options="--retry 20 --retry-delay 2 --connect-timeout 15 -sSL -f --create-dirs "
     local failed=false
@@ -1058,6 +1059,9 @@ get_download_link_from_aka_ms() {
     say_verbose "Constructed aka.ms link: '$aka_ms_link'."
 
     #get HTTP response
+    #do not pass credentials as a part of the $aka_ms_link and do not apply credentials in the get_http_header function
+    #otherwise the redirect link would have credentials as well
+    #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
     response="$(get_http_header "$aka_ms_link" true)"
 
     say_verbose "Received response: $response"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1053,9 +1053,6 @@ get_download_link_from_aka_ms() {
             return 1
         fi
 
-        #feed_credential is the part of redirect link, remove it
-        aka_ms_download_link=$( echo "${aka_ms_download_link%%\?*}" )
-
         say_verbose "The redirect location retrieved: '$aka_ms_download_link'."
         return 0
     else

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1422,6 +1422,7 @@ do
             echo "          For SDK use channel in A.B.Cxx format. Using quality for SDK together with channel in A.B format is not supported." 
             echo "          Supported since 5.0 release." 
             echo "          Note: The version parameter overrides the channel parameter when any version other than `latest` is used, and therefore overrides the quality."
+            echo "  --internal,-Internal               Set this switch to download internal builds. It is necessary to use --feed-credential option with this."
             echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1489,9 +1489,9 @@ script_name=$(basename "$0")
 
 if [ "$dry_run" = true ]; then
     say "Payload URLs:"
-    say "Primary named payload URL: $download_link"
+    say "Primary named payload URL: ${download_link}${feed_credential}"
     if [ "$valid_legacy_download_link" = true ]; then
-        say "Legacy named payload URL: $legacy_download_link"
+        say "Legacy named payload URL: ${legacy_download_link}${feed_credential}"
     fi
     repeatable_command="./$script_name --version "\""$specific_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"" --os "\""$normalized_os"\"""
     

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1534,7 +1534,6 @@ if [ "$dry_run" = true ]; then
         repeatable_command+=" --quality "\""$normalized_quality"\"""
     fi
 
-
     if [[ "$runtime" == "dotnet" ]]; then
         repeatable_command+=" --runtime "\""dotnet"\"""
     elif [[ "$runtime" == "aspnetcore" ]]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1497,6 +1497,10 @@ if [ "$dry_run" = true ]; then
         repeatable_command+=" --quality "\""$normalized_quality"\"""
     fi
 
+    if [ "$internal" = true ]; then
+        repeatable_command+=" --internal"
+    fi
+
     if [[ "$runtime" == "dotnet" ]]; then
         repeatable_command+=" --runtime "\""dotnet"\"""
     elif [[ "$runtime" == "aspnetcore" ]]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -869,7 +869,7 @@ extract_dotnet_package() {
 }
 
 # args:
-# remote_path - $1
+# remote_path - $1 - Note, credentials will not be applied.
 get_http_header()
 {
     eval $invocation
@@ -891,24 +891,22 @@ get_http_header()
 }
 
 # args:
-# remote_path - $1
+# remote_path - $1 - Note, credentials will not be applied.
 get_http_header_curl() {
     eval $invocation
     local remote_path="$1"
-    remote_path_with_credential="${remote_path}${feed_credential}"
     curl_options="-I -sSL --retry 5 --retry-delay 2 --connect-timeout 15 "
-    curl $curl_options "$remote_path_with_credential" || return 1
+    curl $curl_options "$remote_path" || return 1
     return 0
 }
 
 # args:
-# remote_path - $1
+# remote_path - $1 - Note, credentials will not be applied.
 get_http_header_wget() {
     eval $invocation
     local remote_path="$1"
-    remote_path_with_credential="${remote_path}${feed_credential}"
     wget_options="-q -S --spider --tries 5 --waitretry 2 --connect-timeout 15 "
-    wget $wget_options "$remote_path_with_credential" 2>&1 || return 1
+    wget $wget_options "$remote_path" 2>&1 || return 1
     return 0
 }
 
@@ -1043,6 +1041,7 @@ get_download_link_from_aka_ms() {
     #get HTTP response
     response="$(get_http_header "$aka_ms_link")"
 
+    say_verbose "Received response: $response"
     http_code=$( echo "$response" | awk '$1 ~ /^HTTP/ {print $2}' | head -1 )
 
     #if HTTP code is 301 (Moved Permanently), the redirect link exists

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class AkaMsLinksTests : TestBase
     {
+        // This is not how credentials look like, this is just a testing string.
+        private const string _feedCredential = "478a920c-2217-49f2-9c31-2fc3b4fef7cb";
+
         /// <summary>
         /// Test verifies E2E the aka.ms resolution for SDK
         /// </summary>
@@ -169,19 +172,24 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         }
 
         [Theory]
-        [InlineData("2.1", null, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
-        [InlineData("3.1", null, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
-        [InlineData("5.0", null, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
-        [InlineData("5.0.1xx", null, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
-        [InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
-        [InlineData("Current", null, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
-        [InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
-        public void LinkCanBeCreatedForSdk(string channel, string quality, string expectedLink)
+        [InlineData("2.1", null, false, @"https://aka.ms/dotnet/2.1/dotnet-sdk-")]
+        [InlineData("3.1", null, false, @"https://aka.ms/dotnet/3.1/dotnet-sdk-")]
+        [InlineData("5.0", null, false, @"https://aka.ms/dotnet/5.0/dotnet-sdk-")]
+        [InlineData("5.0.1xx", null, false, @"https://aka.ms/dotnet/5.0.1xx/dotnet-sdk-")]
+        [InlineData("5.0.2xx", null, false, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        [InlineData("Current", null, false, @"https://aka.ms/dotnet/current/dotnet-sdk-")]
+        [InlineData("LTS", null, false, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "signed", false, @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "daily", false, @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "validated", false, @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "preview", false, @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "ga", false, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
+        [InlineData("3.1", null, true, @"https://aka.ms/dotnet/internal/3.1/dotnet-sdk-")]
+        [InlineData("5.0.2xx", null, true, @"https://aka.ms/dotnet/internal/5.0.2xx/dotnet-sdk-")]
+        [InlineData("Current", null, true, @"https://aka.ms/dotnet/internal/current/dotnet-sdk-")]
+        [InlineData("LTS", null, true, @"https://aka.ms/dotnet/internal/LTS/dotnet-sdk-")]
+        [InlineData("5.0.2xx", "validated", true, @"https://aka.ms/dotnet/internal/5.0.2xx/validated/dotnet-sdk-")]
+        public void LinkCanBeCreatedForSdk(string channel, string quality, bool isInternal, string expectedLink)
         {
             string expectedLinkPattern = Regex.Escape(expectedLink);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -203,6 +211,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 args.Add(quality);
             }
 
+            if (isInternal)
+            {
+                args.Add("-internal");
+                args.Add("-feedcredential");
+                args.Add(_feedCredential);
+            }
+
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
                             .CaptureStdErr()
@@ -212,36 +227,42 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         }
 
         [Theory]
-        [InlineData("2.1", "dotnet", null, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
-        [InlineData("3.1", "dotnet", null, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
-        [InlineData("Current", "dotnet", null, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
-        [InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
-        [InlineData("2.1", "aspnetcore", null, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
-        [InlineData("3.1", "aspnetcore", null, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
-        [InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
-        [InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
-        [InlineData("3.1", "windowsdesktop", null, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
-        [InlineData("Current", "windowsdesktop", null, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
-        [InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
-        public void LinkCanBeCreatedForGivenRuntime(string channel, string runtime, string quality, string expectedLink)
+        [InlineData("2.1", "dotnet", null, false, @"https://aka.ms/dotnet/2.1/dotnet-runtime-")]
+        [InlineData("3.1", "dotnet", null, false, @"https://aka.ms/dotnet/3.1/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", null, false, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("Current", "dotnet", null, false, @"https://aka.ms/dotnet/current/dotnet-runtime-")]
+        [InlineData("LTS", "dotnet", null, false, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "signed", false, @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "daily", false, @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "validated", false, @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "preview", false, @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "ga", false, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
+        [InlineData("2.1", "aspnetcore", null, false, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
+        [InlineData("3.1", "aspnetcore", null, false, @"https://aka.ms/dotnet/3.1/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", null, false, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("Current", "aspnetcore", null, false, @"https://aka.ms/dotnet/current/aspnetcore-runtime-")]
+        [InlineData("LTS", "aspnetcore", null, false, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "signed", false, @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "daily", false, @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "validated", false, @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "preview", false, @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "ga", false, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
+        [InlineData("3.1", "windowsdesktop", null, false, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", null, false, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        [InlineData("Current", "windowsdesktop", null, false, @"https://aka.ms/dotnet/current/windowsdesktop-runtime-")]
+        [InlineData("LTS", "windowsdesktop", null, false, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "signed", false, @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "daily", false, @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "validated", false, @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "preview", false,  @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "ga", false, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
+        [InlineData("LTS", "dotnet", null, true, @"https://aka.ms/dotnet/internal/LTS/dotnet-runtime-")]
+        [InlineData("5.0", "dotnet", "daily", true, @"https://aka.ms/dotnet/internal/5.0/daily/dotnet-runtime-")]
+        [InlineData("Current", "aspnetcore", null, true, @"https://aka.ms/dotnet/internal/current/aspnetcore-runtime-")]
+        [InlineData("5.0", "aspnetcore", "ga", true, @"https://aka.ms/dotnet/internal/5.0/aspnetcore-runtime-")]
+        [InlineData("LTS", "windowsdesktop", null, true, @"https://aka.ms/dotnet/internal/LTS/windowsdesktop-runtime-")]
+        [InlineData("5.0", "windowsdesktop", "ga", true, @"https://aka.ms/dotnet/internal/5.0/windowsdesktop-runtime-")]
+        public void LinkCanBeCreatedForGivenRuntime(string channel, string runtime, string quality, bool isInternal, string expectedLink)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
             {
@@ -269,83 +290,11 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 args.Add(quality);
             }
 
-            var commandResult = CreateInstallCommand(args)
-                            .CaptureStdOut()
-                            .CaptureStdErr()
-                            .Execute();
-
-            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
-        }
-
-        [Theory]
-        [InlineData("3.1", null, @"https://aka.ms/dotnet/internal/3.1/dotnet-sdk-")]
-        [InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/internal/5.0.2xx/dotnet-sdk-")]
-        [InlineData("Current", null, @"https://aka.ms/dotnet/internal/current/dotnet-sdk-")]
-        [InlineData("LTS", null, @"https://aka.ms/dotnet/internal/LTS/dotnet-sdk-")]
-        [InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/internal/5.0.2xx/validated/dotnet-sdk-")]
-        public void InternalLinkCanBeCreatedForSdk(string channel, string quality, string expectedLink)
-        {
-            string expectedLinkPattern = Regex.Escape(expectedLink);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (isInternal)
             {
-                expectedLinkPattern += "win";
-            }
-            else
-            {
-                expectedLinkPattern += "(linux|linux-musl|osx)";
-            }
-
-            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
-
-            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-internal" };
-
-            if (!string.IsNullOrWhiteSpace (quality))
-            {
-                args.Add("-quality");
-                args.Add(quality);
-            }
-
-            var commandResult = CreateInstallCommand(args)
-                            .CaptureStdOut()
-                            .CaptureStdErr()
-                            .Execute();
-
-            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
-        }
-
-        [Theory]
-        [InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/internal/LTS/dotnet-runtime-")]
-        [InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/internal/5.0/daily/dotnet-runtime-")]
-        [InlineData("Current", "aspnetcore", null, @"https://aka.ms/dotnet/internal/current/aspnetcore-runtime-")]
-        [InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/internal/5.0/aspnetcore-runtime-")]
-        [InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/internal/LTS/windowsdesktop-runtime-")]
-        [InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/internal/5.0/windowsdesktop-runtime-")]
-        public void InternalLinkCanBeCreatedForGivenRuntime(string channel, string runtime, string quality, string expectedLink)
-        {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")
-            {
-                // Do not run windowsdesktop tests on Linux environment.
-                return;
-            }
-
-            string expectedLinkPattern = Regex.Escape(expectedLink);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                expectedLinkPattern += "win";
-            }
-            else
-            {
-                expectedLinkPattern += "(linux|linux-musl|osx)";
-            }
-
-            expectedLinkPattern += "-(x86|x64|arm|arm64)\\.(zip|tar\\.gz)";
-
-            var args = new List<string> { "-dryrun", "-channel", channel, "-verbose", "-runtime", runtime, "-internal" };
-
-            if (!string.IsNullOrWhiteSpace(quality))
-            {
-                args.Add("-quality");
-                args.Add(quality);
+                args.Add("-internal");
+                args.Add("-feedcredential");
+                args.Add(_feedCredential);
             }
 
             var commandResult = CreateInstallCommand(args)

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -223,7 +223,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
 
             if(isInternal)
@@ -310,7 +309,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
 
             if(isInternal)
@@ -361,7 +359,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Specifying quality for current or LTS channel is not supported, the quality will be ignored.");
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
         }

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.Cli.Utils;
 using Xunit;
 using System.Collections.Generic;
 using Microsoft.NET.TestFramework.Assertions;
@@ -12,9 +11,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class AkaMsLinksTests : TestBase
     {
-        // This is not how credentials look like, this is just a testing string.
-        private const string _feedCredential = "478a920c-2217-49f2-9c31-2fc3b4fef7cb";
-
         /// <summary>
         /// Test verifies E2E the aka.ms resolution for SDK
         /// </summary>
@@ -71,6 +67,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .Execute();
 
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
             commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
             commandResult.Should().HaveStdOutContaining("Downloading using legacy url will not be attempted.");
@@ -162,6 +159,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .Execute();
 
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
             commandResult.Should().HaveStdOutContaining("The redirect location retrieved:");
             commandResult.Should().HaveStdOutContaining("Downloading using legacy url will not be attempted.");
@@ -211,11 +209,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 args.Add(quality);
             }
 
+            string feedCredentials = default;
             if (isInternal)
             {
+                feedCredentials = Guid.NewGuid().ToString();
                 args.Add("-internal");
                 args.Add("-feedcredential");
-                args.Add(_feedCredential);
+                args.Add(feedCredentials);
             }
 
             var commandResult = CreateInstallCommand(args)
@@ -223,7 +223,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+
+            if(isInternal)
+            {
+                commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
+            }
         }
 
         [Theory]
@@ -290,11 +296,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 args.Add(quality);
             }
 
+            string feedCredentials = default;
             if (isInternal)
             {
+                feedCredentials = Guid.NewGuid().ToString();
                 args.Add("-internal");
                 args.Add("-feedcredential");
-                args.Add(_feedCredential);
+                args.Add(feedCredentials);
             }
 
             var commandResult = CreateInstallCommand(args)
@@ -302,7 +310,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
+
+            if(isInternal)
+            {
+                commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
+            }
         }
 
         [Theory]
@@ -347,6 +361,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Specifying quality for current or LTS channel is not supported, the quality will be ignored.");
             commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, expectedLinkPattern));
         }
@@ -393,6 +408,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .Execute();
 
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("Retrieving primary payload URL from aka.ms link for channel");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
         }
@@ -410,6 +426,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .Execute();
 
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("Retrieving primary payload URL from aka.ms link for channel");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
         }

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -97,7 +97,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("2.2", "dotnet")]
         [InlineData("3.0", "dotnet")]
         [InlineData("3.1", "dotnet")]
+        [InlineData("3.1", "dotnet", true)]
         [InlineData("5.0", "dotnet")]
+        [InlineData("5.0", "dotnet", true)]
         [InlineData("Current", "dotnet")]
         [InlineData("LTS", "dotnet")]
         [InlineData("master", "dotnet")]
@@ -105,6 +107,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/2.2", "dotnet")]
         [InlineData("release/3.0", "dotnet")]
         [InlineData("release/3.1", "dotnet")]
+        [InlineData("release/3.1", "dotnet", true)]
         // [InlineData("release/5.0", "dotnet")] - Broken
         [InlineData("Current", "aspnetcore")]
         [InlineData("LTS", "aspnetcore")]
@@ -115,23 +118,23 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("3.0", "aspnetcore")]
         [InlineData("3.1", "aspnetcore")]
         [InlineData("5.0", "aspnetcore")]
+        [InlineData("5.0", "aspnetcore", true)]
         [InlineData("master", "aspnetcore")]
-        [InlineData("2.2", "aspnetcore")]
-        [InlineData("3.0", "aspnetcore")]
-        [InlineData("3.1", "aspnetcore")]
-        [InlineData("5.0", "aspnetcore")]
         [InlineData("release/2.1", "aspnetcore")]
         [InlineData("release/2.2", "aspnetcore")]
         //[InlineData("release/3.0", "aspnetcore")] - Broken
         //[InlineData("release/3.1", "aspnetcore")] - Broken
         //[InlineData("release/5.0", "aspnetcore")] - Broken 
         [InlineData("Current", "windowsdesktop")]
+        [InlineData("Current", "windowsdesktop", true)]
         [InlineData("LTS", "windowsdesktop")]
         [InlineData("3.0", "windowsdesktop")]
         [InlineData("3.1", "windowsdesktop")]
         [InlineData("5.0", "windowsdesktop")]
+        [InlineData("5.0", "windowsdesktop", true)]
         [InlineData("master", "windowsdesktop")]
-        public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType, bool internalBuild = false)
+        [InlineData("master", "windowsdesktop", true)]
+        public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType, bool useCustomFeedCredential = false)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtimeType == "windowsdesktop")
             {
@@ -141,11 +144,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             var args = new List<string> { "-dryrun", "-channel", channel, "-runtime", runtimeType };
 
             string feedCredentials = default;
-            if (internalBuild)
+            if (useCustomFeedCredential)
             {
                 feedCredentials = Guid.NewGuid().ToString();
-                args.Add("-internal");
-                args.Add("-feedCredentials");
+                args.Add("-feedCredential");
                 args.Add(feedCredentials);
             }
 
@@ -163,7 +165,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             //  Channel should be translated to a specific Runtime version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
 
-            if (internalBuild)
+            if (useCustomFeedCredential)
             {
                 commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
             }
@@ -211,16 +213,15 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/5.0.1xx-preview7")]
         [InlineData("release/5.0.1xx-preview8")]
         [InlineData("release/5.0.1xx-preview8", true)]
-        public void WhenChannelResolvesToASpecificSDKVersion(string channel, bool internalBuild = false)
+        public void WhenChannelResolvesToASpecificSDKVersion(string channel, bool useFeedCredential = false)
         {
             var args = new List<string> { "-dryrun", "-channel", channel };
 
             string feedCredentials = default;
-            if (internalBuild)
+            if (useFeedCredential)
             {
                 feedCredentials = Guid.NewGuid().ToString();
-                args.Add("-internal");
-                args.Add("-feedCredentials");
+                args.Add("-feedCredential");
                 args.Add(feedCredentials);
             }
 
@@ -238,7 +239,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             //  Channel should be translated to a specific SDK version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
 
-            if (internalBuild)
+            if (useFeedCredential)
             {
                 commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
             }
@@ -271,7 +272,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         public void WhenInvalidChannelWasUsed(string channel)
         {
             string feedCredentials = Guid.NewGuid().ToString();
-            var args = new [] { "-dryrun", "-channel", channel, "-internal", "-feedCredentials", feedCredentials };
+            var args = new [] { "-dryrun", "-channel", channel, "-internal", "-feedCredential", feedCredentials };
             
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class GivenThatIWantToGetTheSdkLinksFromAScript : TestBase
     {
+        // This is not how credentials look like, this is just a testing string.
         private const string _feedCredential = "478a920c-2217-49f2-9c31-2fc3b4fef7cb";
 
         [Theory]

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using FluentAssertions;
+using Microsoft.NET.TestFramework.Assertions;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.Cli.Utils;
 using Xunit;
-using System.Collections.Generic;
-using Microsoft.NET.TestFramework.Assertions;
-using FluentAssertions;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
@@ -132,14 +131,23 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("3.1", "windowsdesktop")]
         [InlineData("5.0", "windowsdesktop")]
         [InlineData("master", "windowsdesktop")]
-        public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType)
+        public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType, bool internalBuild = false)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtimeType == "windowsdesktop")
             {
                 //do not run windowsdesktop test on Linux environment
                 return;
             }
-            var args = new string[] { "-dryrun", "-channel", channel, "-runtime", runtimeType };
+            var args = new List<string> { "-dryrun", "-channel", channel, "-runtime", runtimeType };
+
+            string feedCredentials = default;
+            if (internalBuild)
+            {
+                feedCredentials = Guid.NewGuid().ToString();
+                args.Add("-internal");
+                args.Add("-feedCredentials");
+                args.Add(feedCredentials);
+            }
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -148,11 +156,17 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             //  Standard 'dryrun' criterium
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("dryrun");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
 
             //  Channel should be translated to a specific Runtime version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
+
+            if (internalBuild)
+            {
+                commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
+            }
         }
 
         [Theory]
@@ -169,6 +183,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/1.0.0")]
         [InlineData("release/2.0.0")]
         [InlineData("release/2.0.2")]
+        [InlineData("release/2.0.2", true)]
         [InlineData("release/2.1.1xx")]
         [InlineData("release/2.1.2xx")]
         [InlineData("release/2.1.3xx")]
@@ -180,11 +195,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/2.1.7xx")]
         [InlineData("release/2.1.8xx")]
         [InlineData("release/2.2.1xx")]
+        [InlineData("release/2.2.1xx", true)]
         [InlineData("release/2.2.2xx")]
         [InlineData("release/2.2.3xx")]
         [InlineData("release/2.2.4xx")]
         [InlineData("release/3.0.1xx")]
         [InlineData("release/5.0.1xx")]
+        [InlineData("release/5.0.1xx", true)]
         [InlineData("release/5.0.1xx-preview1")]
         [InlineData("release/5.0.1xx-preview2")]
         [InlineData("release/5.0.1xx-preview3")]
@@ -193,9 +210,19 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/5.0.1xx-preview6")]
         [InlineData("release/5.0.1xx-preview7")]
         [InlineData("release/5.0.1xx-preview8")]
-        public void WhenChannelResolvesToASpecificSDKVersion(string channel)
+        [InlineData("release/5.0.1xx-preview8", true)]
+        public void WhenChannelResolvesToASpecificSDKVersion(string channel, bool internalBuild = false)
         {
-            var args = new string[] { "-dryrun", "-channel", channel };
+            var args = new List<string> { "-dryrun", "-channel", channel };
+
+            string feedCredentials = default;
+            if (internalBuild)
+            {
+                feedCredentials = Guid.NewGuid().ToString();
+                args.Add("-internal");
+                args.Add("-feedCredentials");
+                args.Add(feedCredentials);
+            }
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -204,12 +231,19 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             //  Standard 'dryrun' criterium
             commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("dryrun");
             commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
 
             //  Channel should be translated to a specific SDK version
             commandResult.Should().HaveStdOutContainingIgnoreCase("-version");
+
+            if (internalBuild)
+            {
+                commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
+            }
         }
+
         [Theory]
         [InlineData("5.0.1", "WindowsDesktop")]
         [InlineData("3.1.10", "Runtime")]
@@ -221,14 +255,34 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 return;
             }
             string expectedLinkLog = $"Constructed primary named payload URL: {Environment.NewLine}https://dotnetcli.azureedge.net/dotnet/{location}/{version}";
-            var args = new string[] { "-version", version, "-runtime", "windowsdesktop", "-verbose", "-dryrun"};
+            var args = new string[] { "-version", version, "-runtime", "windowsdesktop", "-verbose", "-dryrun" };
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
                             .CaptureStdErr()
                             .Execute();
 
             commandResult.Should().Pass().And.HaveStdOutContaining(expectedLinkLog);
-        } 
+        }
 
+        [Theory]
+        [InlineData("release/2.6.1xx")]
+        [InlineData("4.8.2")]
+        [InlineData("abcdefg")]
+        public void WhenInvalidChannelWasUsed(string channel)
+        {
+            string feedCredentials = Guid.NewGuid().ToString();
+            var args = new [] { "-dryrun", "-channel", channel, "-internal", "-feedCredentials", feedCredentials };
+            
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            //  Standard 'dryrun' criterium
+            commandResult.Should().Fail();
+            commandResult.Should().NotHaveStdOutContaining("Repeatable invocation:");
+            commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
+            commandResult.Should().NotHaveStdErrContainingIgnoreCase(feedCredentials);
+        }
     }
 }

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -191,6 +191,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/2.1.3xx")]
         [InlineData("release/2.1.4xx")]
         [InlineData("release/2.1.401")]
+        [InlineData("release/2.1.401", true)]
         [InlineData("release/2.1.5xx")]
         [InlineData("release/2.1.502")]
         [InlineData("release/2.1.6xx")]

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -8,7 +8,6 @@ using Xunit;
 using System.Collections.Generic;
 using Microsoft.NET.TestFramework.Assertions;
 using FluentAssertions;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -14,9 +14,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class GivenThatIWantToGetTheSdkLinksFromAScript : TestBase
     {
-        // This is not how credentials look like, this is just a testing string.
-        private const string _feedCredential = "478a920c-2217-49f2-9c31-2fc3b4fef7cb";
-
         [Theory]
         [InlineData("InstallationScriptTests.json")]
         [InlineData("InstallationScriptTestsWithMultipleSdkFields.json")]
@@ -93,32 +90,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             //  Runtime should resolve to the correct 'type'
             commandResult.Should().HaveStdOutContainingIgnoreCase("-runtime");
             commandResult.Should().HaveStdOutContainingIgnoreCase(runtimeType);
-        }
-
-
-        [Theory]
-        [InlineData("3.1", _feedCredential)]
-        [InlineData("5.0.2xx", _feedCredential)]
-        [InlineData("LTS", "?" + _feedCredential)]
-        [InlineData("release/1.0.0", "?" + _feedCredential)]
-        [InlineData("master", _feedCredential)]
-        public void WhenFeedCredentialParameterIsPassedToInstallScripts(string channel, string feedCredential)
-        {
-            var args = new List<string> { "-dryrun", "-channel", channel, "-feedcredential", feedCredential, "-verbose" };
-
-            var commandResult = CreateInstallCommand(args)
-                            .CaptureStdOut()
-                            .CaptureStdErr()
-                            .Execute();
-
-            //  Standard 'dryrun' criterium
-            commandResult.Should().Pass();
-            commandResult.Should().NotHaveStdOutContaining("dryrun");
-            commandResult.Should().HaveStdOutContaining("Repeatable invocation:");
-
-            // Checking format of the link after applying feed credential
-            string linkWithCredentialsExpression = @"Primary named payload URL: [a-zA-Z0-9:/.-]*\?" + feedCredential;
-            commandResult.Should().HaveStdOutContaining(output => Regex.IsMatch(output, linkWithCredentialsExpression));
         }
 
         [Theory]

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -329,7 +329,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string feedCredential = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, feedCredential, true);
+            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, feedCredential, verboseLogging: true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -354,7 +354,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string feedCredential = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, feedCredential, true);
+            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, feedCredential, verboseLogging: true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -383,7 +383,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().HaveStdErrContaining("RuntimeException");
+            commandResult.Should().HaveStdErrContaining("Exception");
             commandResult.Should().NotHaveStdOutContaining("Installation finished");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
         }

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -203,6 +203,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string installPath = " [" + Path.Combine(_sdkInstallationDirectory, "sdk") + "]";
             string regex = Regex.Escape("  ") + versionRegex + Regex.Escape(installPath);
             dotnetCommandResult.Should().HaveStdOutMatching(regex);
+            commandResult.Should().NotHaveStdErr();
         }
 
         [Theory]
@@ -238,6 +239,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string lineEnd = " [" + Path.Combine(_sdkInstallationDirectory, "shared", "Microsoft.NETCore.App") + "]";
             string regex = Regex.Escape(lineStart) + versionRegex + Regex.Escape(lineEnd);
             dotnetCommandResult.Should().HaveStdOutMatching(regex);
+            commandResult.Should().NotHaveStdErr();
         }
 
         [Theory]
@@ -276,6 +278,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string lineEnd = " [" + Path.Combine(_sdkInstallationDirectory, "shared", "Microsoft.AspNetCore.App") + "]";
             string regex = Regex.Escape(lineStart) + versionRegex + Regex.Escape(lineEnd);
             dotnetCommandResult.Should().HaveStdOutMatching(regex);
+            commandResult.Should().NotHaveStdErr();
         }
 
         [Theory]
@@ -312,6 +315,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Installation finished");
 
             // Dotnet CLI is not included in the windowsdesktop runtime. Therefore, version validation cannot be tested.
@@ -325,13 +329,14 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string guid = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, guid);
+            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, guid, true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Installation finished");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
         }
@@ -349,13 +354,14 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string guid = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, guid);
+            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, guid, true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
                             .CaptureStdErr()
                             .Execute();
 
+            commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Installation finished");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
         }

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -326,10 +326,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [MemberData(nameof(InstallSdkFromChannelTestCases))]
         public void WhenInstallingTheSdkWithFeedCredential(string channel, string? quality, string versionRegex)
         {
-            string guid = "?" + Guid.NewGuid().ToString();
+            string feedCredential = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, guid, true);
+            var args = GetInstallScriptArgs(channel, null, quality, _sdkInstallationDirectory, feedCredential, true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -338,7 +338,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Installation finished");
-            commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
+            commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredential);
         }
 
         [Theory]
@@ -351,10 +351,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 // Broken scenario
                 return;
             }
-            string guid = "?" + Guid.NewGuid().ToString();
+            string feedCredential = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, guid, true);
+            var args = GetInstallScriptArgs(channel, "dotnet", quality, _sdkInstallationDirectory, feedCredential, true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -363,7 +363,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             commandResult.Should().NotHaveStdErr();
             commandResult.Should().HaveStdOutContaining("Installation finished");
-            commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
+            commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredential);
         }
 
         [Theory]
@@ -379,10 +379,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("dotnet", "LTS", "invalidQuality")]
         public void WhenFailingToInstallWithFeedCredentials(string? runtime, string channel, string? quality)
         {
-            string guid = "?" + Guid.NewGuid().ToString();
+            string feedCredential = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, runtime, quality, _sdkInstallationDirectory, guid, verboseLogging: true);
+            var args = GetInstallScriptArgs(channel, runtime, quality, _sdkInstallationDirectory, feedCredential, verboseLogging: true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -391,7 +391,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             commandResult.Should().HaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("Installation finished");
-            commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
+            commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredential);
         }
 
         private static IEnumerable<string> GetInstallScriptArgs(

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -356,8 +356,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().HaveStdErrContaining("RuntimeException");
-            commandResult.Should().NotHaveStdOutContaining("Installation finished");
+            commandResult.Should().HaveStdOutContaining("Installation finished");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
         }
 
@@ -377,7 +376,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string guid = "?" + Guid.NewGuid().ToString();
 
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(channel, runtime, quality, _sdkInstallationDirectory, guid);
+            var args = GetInstallScriptArgs(channel, runtime, quality, _sdkInstallationDirectory, guid, verboseLogging: true);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -394,7 +393,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             string? runtime,
             string? quality, 
             string? installDir, 
-            string? feedCredentials = null)
+            string? feedCredentials = null,
+            bool verboseLogging = false)
         {
             if (!string.IsNullOrWhiteSpace(channel))
             {
@@ -424,6 +424,11 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             {
                 yield return "-FeedCredential";
                 yield return feedCredentials;
+            }
+
+            if (verboseLogging)
+            {
+                yield return "-Verbose";
             }
         }
 

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -383,7 +383,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                             .CaptureStdErr()
                             .Execute();
 
-            commandResult.Should().HaveStdErrContaining("Exception");
+            commandResult.Should().HaveStdErr();
             commandResult.Should().NotHaveStdOutContaining("Installation finished");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(guid);
         }

--- a/tests/Install-Scripts.Test/Utils/CommandResultAssertions.cs
+++ b/tests/Install-Scripts.Test/Utils/CommandResultAssertions.cs
@@ -134,6 +134,13 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdErrContainingIgnoreCase(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdErr.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                .FailWith(AppendDiagnosticsTo($"The command error output contained a result it should not have contained (ignoring case): {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdErr, pattern, options).Success)

--- a/tests/Install-Scripts.Test/Utils/CommandResultAssertions.cs
+++ b/tests/Install-Scripts.Test/Utils/CommandResultAssertions.cs
@@ -74,6 +74,13 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdOutContainingIgnoreCase(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                .FailWith(AppendDiagnosticsTo($"The command output contained a result it should not have contained (ignoring case): {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreSpaces(string pattern)
         {
             string commandResultNoSpaces = _commandResult.StdOut.Replace(" ", "");
@@ -87,7 +94,7 @@ namespace Microsoft.NET.TestFramework.Assertions
 
         public AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreCase(string pattern)
         {
-            Execute.Assertion.ForCondition(_commandResult.StdOut.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0)
+            Execute.Assertion.ForCondition(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase))
                 .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result (ignoring case): {pattern}{Environment.NewLine}"));
             return new AndConstraint<CommandResultAssertions>(this);
         }


### PR DESCRIPTION
Changes in this PR:
- Adding --internal switch for aka.ms links.
- Fixing usage of the credentials for aka.ms links (previously credentials were applied twice and as a result the final link had wrong format).
- Prevent echoing of credentials given --feed-credential switch.

Delivers issue #169.