### PR TITLE
Don't use unavailable wget options

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1176,7 +1176,9 @@ calculate_vars() {
             fi
     fi
 
-    if [[ ${specific_version=$(get_specific_version_from_version "$azure_feed" "$channel" "$normalized_architecture" "$version" "$json_file")} != 0 ]]; then
+    specific_version=$(get_specific_version_from_version "$azure_feed" "$channel" "$normalized_architecture" "$version" "$json_file") || specific_version='0'
+
+    if [[ "$specific_version" == '0' ]]; then
         say_err "Could not resolve version information."
         return 1
     fi


### PR DESCRIPTION
Fixes https://github.com/dotnet/install-scripts/issues/216

**Problem:** Some options of `wget` are not available on Alpine.

**Solution:** The changes in this PR detects the missing options and removes them.
The implication of this removal will be that scripts running on alpine+wget will be quicker to give up on retrying. This should be acceptable considering that:
- We already have a custom retry logic built-in in a higher level,
- The issue can simply be resolved by installing curl.