### PR TITLE
Move off Arcade-Pool-Provider

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,11 +171,11 @@ stages:
     container: LinuxContainer
     pool:
       ${{ if eq(variables._RunAsPublic, True) }}:
-        name:  NetCorePublic-Pool
-        queue: BuildPool.Ubuntu.1604.Amd64.Open
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
       ${{ if eq(variables._RunAsInternal, True) }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Ubuntu.1604.Amd64
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
     steps:
     - checkout: self
       displayName: Checkout Self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,11 +35,11 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019
         strategy:
           matrix:
             ${{ if eq(variables._RunAsInternal, True) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,10 +36,10 @@ stages:
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017
         strategy:
           matrix:
             ${{ if eq(variables._RunAsInternal, True) }}:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     timeoutInMinutes: 90
     pool:
       name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      demands: ImageOverride -equals Build.Server.Amd64.VS2017
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -19,8 +19,8 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     pool:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Server.Amd64.VS2017.Arcade
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("6.0", "6\\.0\\..*", Quality.Daily),
                 ("6.0", "6\\.0\\..*", Quality.None),
                 ("Current", "5\\.0\\..*", Quality.None),
-                ("LTS", "3\\.1\\..*", Quality.None),
+                ("LTS", "6\\.0\\..*", Quality.None),
             };
 
         /// <summary>

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("5.0", "5\\.0\\..*", Quality.None),
                 ("6.0", "6\\.0\\..*", Quality.Daily),
                 ("6.0", "6\\.0\\..*", Quality.None),
-                ("Current", "5\\.0\\..*", Quality.None),
+                ("Current", "6\\.0\\..*", Quality.None),
                 ("LTS", "6\\.0\\..*", Quality.None),
             };
 


### PR DESCRIPTION
Noted while cleaning up arcade stuff, this repo seems to be using the .Arcade queues which will be deleted soon as they were only for Arcade and we're not supposed to be using them any more (Arcade isn't)