### PR TITLE
Update System.Text.Encodings.Web version 4.5.1

### DIFF
--- a/src/MonitoringFunctions.Common/MonitoringFunctions.Common.csproj
+++ b/src/MonitoringFunctions.Common/MonitoringFunctions.Common.csproj
@@ -12,6 +12,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="8.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    
+    <!-- This package has vulnerabilities below version 4.5.1.
+      We do not need to directly reference this package, but it is one of the dependencies of Microsoft.NET.Sdk.Functions.
+      Latest version of Microsoft.NET.Sdk.Functions package today is 4.0.1,
+      which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
+      To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 
 </Project>

--- a/src/MonitoringFunctions.Common/MonitoringFunctions.Common.csproj
+++ b/src/MonitoringFunctions.Common/MonitoringFunctions.Common.csproj
@@ -19,6 +19,9 @@
       which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
       To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <!-- Same scenario above also applies to Microsoft.AspNetCore.Http, where vulnerable 2.1.0 version is referenced. -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
+
   </ItemGroup>
 
 </Project>

--- a/src/MonitoringFunctions.Linux/MonitoringFunctions.Linux.csproj
+++ b/src/MonitoringFunctions.Linux/MonitoringFunctions.Linux.csproj
@@ -15,6 +15,8 @@
       which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
       To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <!-- Same scenario above also applies to Microsoft.AspNetCore.Http, where vulnerable 2.1.0 version is referenced. -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/MonitoringFunctions.Linux/MonitoringFunctions.Linux.csproj
+++ b/src/MonitoringFunctions.Linux/MonitoringFunctions.Linux.csproj
@@ -8,6 +8,13 @@
     <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    
+    <!-- This package has vulnerabilities below version 4.5.1.
+      We do not need to directly reference this package, but it is one of the dependencies of Microsoft.NET.Sdk.Functions.
+      Latest version of Microsoft.NET.Sdk.Functions package today is 4.0.1,
+      which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
+      To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/MonitoringFunctions.Windows/MonitoringFunctions.Windows.csproj
+++ b/src/MonitoringFunctions.Windows/MonitoringFunctions.Windows.csproj
@@ -23,6 +23,8 @@
       which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
       To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <!-- Same scenario above also applies to Microsoft.AspNetCore.Http, where vulnerable 2.1.0 version is referenced. -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonitoringFunctions.Common\MonitoringFunctions.Common.csproj" />

--- a/src/MonitoringFunctions.Windows/MonitoringFunctions.Windows.csproj
+++ b/src/MonitoringFunctions.Windows/MonitoringFunctions.Windows.csproj
@@ -16,6 +16,13 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
+    
+    <!-- This package has vulnerabilities below version 4.5.1.
+      We do not need to directly reference this package, but it is one of the dependencies of Microsoft.NET.Sdk.Functions.
+      Latest version of Microsoft.NET.Sdk.Functions package today is 4.0.1,
+      which depends on version 4.5.0 of System.Text.Encodings.Web (a version that is known to have vulnerabilities).
+      To force the project to use 4.5.1 instead of 4.5.0, we need to add this package reference explicitly. -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonitoringFunctions.Common\MonitoringFunctions.Common.csproj" />


### PR DESCRIPTION
Patch for the vulnerability https://github.com/dotnet/runtime/issues/49377

This PR updates vulnerable versions of `System.Text.Encodings.Web` (4.5.0) and `Microsoft.AspNetCore.Http` (2.1.0) to versions 4.5.1 and 2.1.22 respectively.

Both of these dependencies are referenced by `Microsoft.NET.Sdk.Functions`, which is likely to be updated to contain the secure versions of these packages. However, as of today, even the latest version of `Microsoft.NET.Sdk.Functions` package still references the vulnerable versions. Therefore, fix in this PR includes explicitly referencing the packages in the affected projects.