### PR TITLE
Wrong legacy links are created on bash script

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1261,7 +1261,7 @@ generate_regular_links() {
     if [ "$valid_legacy_download_link" = true ]; then
         say_verbose "Constructed legacy named payload URL: $legacy_download_link"
     
-        download_links+=($download_link)
+        download_links+=($legacy_download_link)
         specific_versions+=($specific_version)
         effective_versions+=($effective_version)
         link_types+=("legacy")

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+*.received.*

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
@@ -4,8 +4,8 @@ dotnet-install: - The SDK needs to be installed without user interaction and wit
 dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
 dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-linux-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-centos-x64.1.0.5.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-linux-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-centos-x64.1.0.5.tar.gz
-dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "1.0.5" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" --runtime "dotnet" -runtimeid "centos.7"
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "1.0.5" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" --runtime "dotnet" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
@@ -1,0 +1,11 @@
+﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
+dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-linux-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-centos-x64.1.0.5.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-linux-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-centos-x64.1.0.5.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "1.0.5" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" --runtime "dotnet" -runtimeid "centos.7"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -1,0 +1,9 @@
+﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
+dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-linux-x64.tar.gz
+dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-linux-x64.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "2.1.0" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" --runtime "aspnetcore" -runtimeid "centos.7"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -4,6 +4,6 @@ dotnet-install: - The SDK needs to be installed without user interaction and wit
 dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
 dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-linux-x64.tar.gz
-dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-linux-x64.tar.gz
-dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "2.1.0" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" --runtime "aspnetcore" -runtimeid "centos.7"
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "2.1.0" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" --runtime "aspnetcore" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=.verified.txt
@@ -1,0 +1,11 @@
+﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
+dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-linux-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-centos-x64.6.0.100.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-linux-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-centos-x64.6.0.100.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "6.0.100" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" -runtimeid "centos.7"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=null.verified.txt
@@ -4,8 +4,8 @@ dotnet-install: - The SDK needs to be installed without user interaction and wit
 dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
 dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-linux-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-centos-x64.6.0.100.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-linux-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-centos-x64.6.0.100.tar.gz
-dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "6.0.100" --install-dir "/home/bozturk/.dotnet" --architecture "x64" --os "linux" -runtimeid "centos.7"
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "6.0.100" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
@@ -7,4 +7,4 @@ dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime
 dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
 dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
-dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "1.0.5" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64" -Runtime "dotnet"
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "1.0.5" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "dotnet"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
@@ -1,0 +1,10 @@
+﻿dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "1.0.5" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64" -Runtime "dotnet"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -5,4 +5,4 @@ dotnet-install: To set up a development environment or to run apps, use installe
 dotnet-install: Payload URLs:
 dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
 dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
-dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "2.1.0" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64" -Runtime "aspnetcore"
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "2.1.0" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "aspnetcore"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -1,0 +1,8 @@
+﻿dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "2.1.0" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64" -Runtime "aspnetcore"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
@@ -7,4 +7,4 @@ dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0
 dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
 dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
-dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "6.0.100" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64"
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "6.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
@@ -1,0 +1,10 @@
+﻿dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
+dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
+dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "6.0.100" -InstallDir "C:\Users\bozturk\AppData\Local\Microsoft\dotnet" -Architecture "x64"

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -342,11 +342,22 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             
             if( string.IsNullOrWhiteSpace(runtime))
             {
-                args = new string[] { "-version", version, "-runtimeid", "centos.7", "-dryrun" };
+                args = new string[] {
+                    "-version", version,
+                    "-runtimeid", "osx", 
+                    "--os", "osx",
+                    "-installdir", "dotnet-sdk",
+                    "-dryrun" };
             }
             else
             {
-                args = new string[] { "-version", version, "-runtimeid", "centos.7", "-runtime", runtime, "-dryrun" };
+                args = new string[] { 
+                    "-version", version,
+                    "-runtimeid", "osx",
+                    "-runtime", runtime,
+                    "--os", "osx",
+                    "-installdir", "dotnet-sdk",
+                    "-dryrun" };
             }
 
             var commandResult = CreateInstallCommand(args)
@@ -374,11 +385,18 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             
             if( string.IsNullOrWhiteSpace(runtime))
             {
-                args = new string[] { "-version", version, "-dryrun" };
+                args = new string[] { 
+                    "-version", version,
+                    "-installdir", "dotnet-sdk",
+                    "-dryrun" };
             }
             else
             {
-                args = new string[] { "-version", version, "-runtime", runtime, "-dryrun" };
+                args = new string[] { 
+                    "-version", version, 
+                    "-runtime", runtime, 
+                    "-installdir", "dotnet-sdk",
+                    "-dryrun" };
             }
 
             var commandResult = CreateInstallCommand(args)

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -6,12 +6,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using VerifyTests;
 using Xunit;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
     public class GivenThatIWantToGetTheSdkLinksFromAScript : TestBase
     {
+        public GivenThatIWantToGetTheSdkLinksFromAScript(VerifySettings settings = null) 
+            : base(settings) { }
+
         [Theory]
         [InlineData("InstallationScriptTests.json")]
         [InlineData("InstallationScriptTestsWithMultipleSdkFields.json")]
@@ -320,6 +325,70 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             {
                 commandResult.Should().HaveStdOutContainingIgnoreCase("-install-dir \"installation_path\"");
             }
+        }
+
+        [Theory]
+        [InlineData("1.0.5", "dotnet")]
+        [InlineData("2.1.0", "aspnetcore")]
+        [InlineData("6.0.100", null)]
+        public async Task WhenAnExactVersionIsPassedToBash(string version, string runtime)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //do not run bash test on Windows environment
+                return;
+            }
+            string[] args;
+            
+            if( string.IsNullOrWhiteSpace(runtime))
+            {
+                args = new string[] { "-version", version, "-runtimeid", "centos.7", "-dryrun" };
+            }
+            else
+            {
+                args = new string[] { "-version", version, "-runtimeid", "centos.7", "-runtime", runtime, "-dryrun" };
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
+            await Verify(commandResult.StdOut).UseParameters(version,runtime);
+        }
+
+        [Theory]
+        [InlineData("1.0.5", "dotnet")]
+        [InlineData("2.1.0", "aspnetcore")]
+        [InlineData("6.0.100", null)]
+        public async Task WhenAnExactVersionIsPassedToPowershell(string version, string? runtime)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //do not run powershell test on Linux environment
+                return;
+            }
+            string[] args;
+            
+            if( string.IsNullOrWhiteSpace(runtime))
+            {
+                args = new string[] { "-version", version, "-dryrun" };
+            }
+            else
+            {
+                args = new string[] { "-version", version, "-runtime", runtime, "-dryrun" };
+            }
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Pass();
+            commandResult.Should().NotHaveStdErr();
+            await Verify(commandResult.StdOut).UseParameters(version, runtime);
         }
     }
 }

--- a/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
+++ b/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.2.402" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Verify.Xunit" Version="14.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Install-Scripts.Test/TestBase.cs
+++ b/tests/Install-Scripts.Test/TestBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
     public abstract class TestBase : VerifyBase
     {
         protected TestBase(VerifySettings settings = null, [CallerFilePath] string sourceFile = "")
-            : base(settings, Path.Combine(Path.GetDirectoryName(sourceFile), "Assets", "foo.cs")) { }
+            : base(settings, Path.Combine(Path.GetDirectoryName(sourceFile) ?? "", "Assets", "foo.cs")) { }
 
         protected static Command CreateInstallCommand(IEnumerable<string> args)
         {

--- a/tests/Install-Scripts.Test/TestBase.cs
+++ b/tests/Install-Scripts.Test/TestBase.cs
@@ -3,11 +3,17 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
 using System.Collections.Generic;
+using VerifyXunit;
+using VerifyTests;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.InstallationScript.Tests
 {
-    public abstract class TestBase
+    public abstract class TestBase : VerifyBase
     {
+        protected TestBase(VerifySettings settings = null, [CallerFilePath] string sourceFile = "")
+            : base(settings, Path.Combine(Path.GetDirectoryName(sourceFile), "Assets", "foo.cs")) { }
+
         protected static Command CreateInstallCommand(IEnumerable<string> args)
         {
             string path;


### PR DESCRIPTION
This PR updates the bash script to use the correct legacy links.