### PR TITLE
fix bashscript for run in sudo sh environment

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,6 +638,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
+            say_verbose "!!!!!!!!!specific_product_version from CURL ${specific_product_version}"
             if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
@@ -665,11 +666,14 @@ get_specific_product_version_from_curl() {
     eval $invocation
 
     local download_link="$1"
-    local specific_product_version=null
-    say_verbose "!!!!!!!!!Before curl call"
-    specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
-    echo "$specific_product_version"
-    return 0
+    local specific_product_version=""
+     if [ -z "$download_link" ]; then
+        say_verbose "!!!!!!!!!Before curl call ${download_link}${feed_credential}"
+        specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+        say_verbose "!!!!!!!!!specific_product_version ${specific_product_version}"
+        echo "$specific_product_version"
+        return 0
+    fi
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -641,7 +641,7 @@ get_specific_product_version() {
             specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
             say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
             if [ $? -ne 0 ] ; then
-                say_verbose "Error: ""$m"
+                say_verbose "Error: ""$specific_product_version"
             fi
             if [ $? = 0 ]; then
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -637,14 +637,13 @@ get_specific_product_version() {
 
         if machine_has "curl"
         then
-            specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
-            if [ ! -z "$specific_product_version" ]; then
+            if ! specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1); then
+                break
+            else
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
-            else
-                say_verbose "In Else statement"
-                break
             fi
+
         elif machine_has "wget"
         then
             specific_product_version=$(wget -qO- "${download_link}${feed_credential}" 2>&1)
@@ -655,28 +654,11 @@ get_specific_product_version() {
         fi
     done
     
-    say_verbose "Failed for ${download_link}"
     # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
     say_verbose "Failed to get the version using productVersion.txt file. Download link will be parsed instead."
     specific_product_version="$(get_product_specific_version_from_download_link "$package_download_link" "$specific_version")"
     echo "${specific_product_version//[$'\t\r\n']}"
     return 0
-}
-
-# args:
-# download link - $1
-get_specific_product_version_from_curl() {
-    eval $invocation
-
-    local download_link="$1"
-    local specific_product_version=""
-     if [ ! -z "$download_link" ]; then
-        say_verbose "!!!!!!!!!Before curl call ${download_link}${feed_credential}"
-        specific_product_version=$(curl -sf -L -s --fail "${download_link}${feed_credential}" 2>&1)
-        say_verbose "!!!!!!!!!specific_product_version ${specific_product_version}"
-        echo "$specific_product_version"
-        return 0
-    fi
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -640,7 +640,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             say_verbose "!!! Before CURL invocation ${download_link}"
-            specific_product_version=$(curl --fail --verbose "${download_link}${feed_credential}" 2>&1)
+            specific_product_version="$get_specific_product_version_from_curl "$download_link""
             say_verbose "!!! After CURL invocation"
             if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
@@ -661,6 +661,15 @@ get_specific_product_version() {
     specific_product_version="$(get_product_specific_version_from_download_link "$package_download_link" "$specific_version")"
     echo "${specific_product_version//[$'\t\r\n']}"
     return 0
+}
+
+# args:
+# download link - $1
+get_specific_product_version_from_curl() {
+    local download_link="$1"
+    local specific_product_version=null
+    specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+    echo "$specific_product_version"
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -632,13 +632,16 @@ get_specific_product_version() {
     local download_links=($(get_specific_product_version_url "$azure_feed" "$specific_version" true "$package_download_link")
         $(get_specific_product_version_url "$azure_feed" "$specific_version" false "$package_download_link"))
     say_verbose "!!! after dl ${download_links[0]}"
+    echo "${download_links[*]}"
     for download_link in "${download_links[@]}"
     do
         say_verbose "Checking for the existence of $download_link"
 
         if machine_has "curl"
         then
-            specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+            say_verbose "!!! Before CURL invocation"
+            specific_product_version=$(curl --fail "${download_link}${feed_credential}" 2>&1)
+             say_verbose "!!! After CURL invocation"
             if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,7 +638,8 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
-            specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+            specific_product_version=$(curl --fail "${download_link}${feed_credential}" --verbose 2>&1)
+            say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
             say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
             if [ $? -ne 0 ] ; then
                 say_verbose "Error: ""$specific_product_version"
@@ -1255,6 +1256,7 @@ generate_regular_links() {
     fi
 
     effective_version="$(get_specific_product_version "$feed" "$specific_version")"
+    say_verbose "effective_version=$effective_version"
     say_verbose "specific_version=$specific_version"
 
     download_link="$(construct_download_link "$feed" "$channel" "$normalized_architecture" "$specific_version" "$normalized_os")"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -672,7 +672,7 @@ get_specific_product_version_from_curl() {
     local specific_product_version=""
      if [ ! -z "$download_link" ]; then
         say_verbose "!!!!!!!!!Before curl call ${download_link}${feed_credential}"
-        specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+        specific_product_version=$(curl -sf -L -s --fail "${download_link}${feed_credential}" 2>&1)
         say_verbose "!!!!!!!!!specific_product_version ${specific_product_version}"
         echo "$specific_product_version"
         return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,7 +642,7 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ $? = 0 && [!-z "$specific_product_version"] ]; then
+            if [ !-z "$specific_product_version" ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,7 +642,7 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ $? = 0 && !-z "$specific_product_version" ]; then
+            if [ $? = 0 && [!-z "$specific_product_version"] ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,7 +642,7 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ $? = 0 ]; then
+            if [ $? = 0 && !-z "$specific_product_version" ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi
@@ -666,10 +666,14 @@ get_specific_product_version() {
 # args:
 # download link - $1
 get_specific_product_version_from_curl() {
+
+    eval $invocation
+
     local download_link="$1"
     local specific_product_version=null
     specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
     echo "$specific_product_version"
+    return 0
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,6 +642,7 @@ get_specific_product_version() {
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             else
+                say_verbose "In Else statement"
                 break
             fi
         elif machine_has "wget"
@@ -654,6 +655,7 @@ get_specific_product_version() {
         fi
     done
     
+    say_verbose "Failed for ${download_link}"
     # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
     say_verbose "Failed to get the version using productVersion.txt file. Download link will be parsed instead."
     specific_product_version="$(get_product_specific_version_from_download_link "$package_download_link" "$specific_version")"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,7 +638,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             if ! specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1); then
-                break
+                continue
             else
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -639,9 +639,9 @@ get_specific_product_version() {
 
         if machine_has "curl"
         then
-            say_verbose "!!! Before CURL invocation"
-            specific_product_version=$(curl --fail "${download_link}${feed_credential}" 2>&1)
-             say_verbose "!!! After CURL invocation"
+            say_verbose "!!! Before CURL invocation ${download_link}"
+            specific_product_version=$(curl --fail --verbose "${download_link}${feed_credential}" 2>&1)
+            say_verbose "!!! After CURL invocation"
             if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -650,7 +650,7 @@ get_specific_product_version() {
                 return 0
             fi
         else
-            echo "!!!!!!!!!!!!!! specific_product_version remains null"
+            say_verbose "!!!!!!!!!!!!!! specific_product_version remains null"
         fi
     done
     

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -614,6 +614,7 @@ construct_download_link() {
 # specific_version - $2
 # download link - $3 (optional)
 get_specific_product_version() {
+    say_verbose "!!! in get_specific_product_version"
     # If we find a 'productVersion.txt' at the root of any folder, we'll use its contents
     # to resolve the version of what's in the folder, superseding the specified version.
     # if 'productVersion.txt' is missing but download link is already available, product version will be taken from download link
@@ -626,11 +627,11 @@ get_specific_product_version() {
         local package_download_link="$3"
     fi
     local specific_product_version=null
-
+    say_verbose "!!! before dl"
     # Try to get the version number, using the productVersion.txt file located next to the installer file.
     local download_links=($(get_specific_product_version_url "$azure_feed" "$specific_version" true "$package_download_link")
         $(get_specific_product_version_url "$azure_feed" "$specific_version" false "$package_download_link"))
-
+    say_verbose "!!! after dl ${download_links[0]}"
     for download_link in "${download_links[@]}"
     do
         say_verbose "Checking for the existence of $download_link"
@@ -665,6 +666,7 @@ get_specific_product_version() {
 # is_flattened - $3
 # download link - $4 (optional)
 get_specific_product_version_url() {
+    say_verbose "!!! in get_specific_product_version_url"
     eval $invocation
 
     local azure_feed="$1"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,7 +642,7 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ [$? = 0 && !-z "$specific_product_version"] ]; then
+            if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,8 +638,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
-            say_verbose "!!!!!!!!!specific_product_version from CURL ${specific_product_version}"
-            if [ $? = 0 ]; then
+            if [! -z "$specific_product_version"]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi
@@ -667,7 +666,7 @@ get_specific_product_version_from_curl() {
 
     local download_link="$1"
     local specific_product_version=""
-     if [ !-z "$download_link" ]; then
+     if [ ! -z "$download_link" ]; then
         say_verbose "!!!!!!!!!Before curl call ${download_link}${feed_credential}"
         specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
         say_verbose "!!!!!!!!!specific_product_version ${specific_product_version}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -637,14 +637,14 @@ get_specific_product_version() {
 
         if machine_has "curl"
         then
-            say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
+            say_verbose "!!!!!!!!!!!!!! dl ${download_link}"
             specific_product_version=$(curl --fail "${download_link}${feed_credential}" --verbose 2>&1)
-            say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
-            say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
-            if [ $? -ne 0 ] ; then
-                say_verbose "Error: ""$specific_product_version"
+            say_verbose "!!!!!!!!!!!!!!"
+            local err = $?
+            if [ err -ne 0 ] ; then
+                say_verbose "Error: ${err}"
             fi
-            if [ $? = 0 ]; then
+            if [ err = 0 ]; then
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -614,7 +614,6 @@ construct_download_link() {
 # specific_version - $2
 # download link - $3 (optional)
 get_specific_product_version() {
-    say_verbose "!!! in get_specific_product_version"
     # If we find a 'productVersion.txt' at the root of any folder, we'll use its contents
     # to resolve the version of what's in the folder, superseding the specified version.
     # if 'productVersion.txt' is missing but download link is already available, product version will be taken from download link
@@ -631,23 +630,17 @@ get_specific_product_version() {
     # Try to get the version number, using the productVersion.txt file located next to the installer file.
     local download_links=($(get_specific_product_version_url "$azure_feed" "$specific_version" true "$package_download_link")
         $(get_specific_product_version_url "$azure_feed" "$specific_version" false "$package_download_link"))
-    say_verbose "!!! after dl ${download_links[0]}"
-    echo "${download_links[*]}"
+
     for download_link in "${download_links[@]}"
     do
         say_verbose "Checking for the existence of $download_link"
 
         if machine_has "curl"
         then
-            say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             if [ $? = 0 ]; then
-                say_verbose "!!! After SUCCESSUL CURL invocation"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
-            else 
-                say_verbose "!!! After FAILED CURL invocation"
-                break
             fi
         elif machine_has "wget"
         then
@@ -673,6 +666,7 @@ get_specific_product_version_from_curl() {
 
     local download_link="$1"
     local specific_product_version=null
+    say_verbose "!!!!!!!!!Before curl call"
     specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
     echo "$specific_product_version"
     return 0
@@ -684,7 +678,6 @@ get_specific_product_version_from_curl() {
 # is_flattened - $3
 # download link - $4 (optional)
 get_specific_product_version_url() {
-    say_verbose "!!! in get_specific_product_version_url"
     eval $invocation
 
     local azure_feed="$1"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -639,6 +639,7 @@ get_specific_product_version() {
         then
             specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
             if [ $? = 0 ]; then
+                say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi
@@ -646,6 +647,7 @@ get_specific_product_version() {
         then
             specific_product_version=$(wget -qO- "${download_link}${feed_credential}" 2>&1)
             if [ $? = 0 ]; then
+                say_verbose "!!!!!!!!!!!!!! wget ${specific_product_version//[$'\t\r\n']} "
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1210,6 +1210,7 @@ generate_akams_links() {
         download_links+=($download_link)
         specific_versions+=($specific_version)
         effective_versions+=($effective_version)
+        say_verbose "!!!!!! Effective version ${effective_version} aka.ms"
         link_types+=("aka.ms")
 
         #  Check if the SDK version is already installed.
@@ -1254,6 +1255,7 @@ generate_regular_links() {
     download_links+=($download_link)
     specific_versions+=($specific_version)
     effective_versions+=($effective_version)
+    say_verbose "!!!!!! Effective version $effective_version PRIMARY"
     link_types+=("primary")
 
     legacy_download_link="$(construct_legacy_download_link "$feed" "$channel" "$normalized_architecture" "$specific_version")" || valid_legacy_download_link=false
@@ -1264,6 +1266,7 @@ generate_regular_links() {
         download_links+=($legacy_download_link)
         specific_versions+=($specific_version)
         effective_versions+=($effective_version)
+            say_verbose "!!!!!! Effective version $effective_version  LEGACY"
         link_types+=("legacy")
     else
         legacy_download_link=""
@@ -1353,6 +1356,7 @@ install_dotnet() {
         download_link="${download_links[$link_index]}"
         specific_version="${specific_versions[$link_index]}"
         effective_version="${effective_versions[$link_index]}"
+        say_verbose "!!!!!! Effective version ${effective_versions[$link_index]} ${link_types[$link_index]}"
         link_type="${link_types[$link_index]}"
 
         say "Attempting to download using $link_type link $download_link"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,7 +638,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
-            if [ ! -z "$specific_product_version"]; then
+            if [ ! -z "$specific_product_version" ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             else

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -640,6 +640,9 @@ get_specific_product_version() {
             say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
             specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
             say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
+            if [ $? -ne 0 ] ; then
+                say_verbose "Error: ""$m"
+            fi
             if [ $? = 0 ]; then
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,9 +638,11 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
-            if [! -z "$specific_product_version"]; then
+            if [ ! -z "$specific_product_version"]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
+            else
+                break
             fi
         elif machine_has "wget"
         then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -639,12 +639,9 @@ get_specific_product_version() {
         then
             say_verbose "!!!!!!!!!!!!!! dl ${download_link}"
             specific_product_version=$(curl --fail "${download_link}${feed_credential}" --verbose 2>&1)
-            say_verbose "!!!!!!!!!!!!!!"
-            local err = $?
-            if [ err -ne 0 ] ; then
-                say_verbose "Error: ${err}"
-            fi
-            if [ err = 0 ]; then
+            if [ $? -ne 0 ] ; then
+                say_verbose "Error: ${specific_product_version}"
+            else then
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -650,7 +650,7 @@ get_specific_product_version() {
                 return 0
             fi
         else
-         say_verbose "!!!!!!!!!!!!!! specific_product_version remains null"
+            echo "!!!!!!!!!!!!!! specific_product_version remains null"
         fi
     done
     

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -638,7 +638,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
-            specific_product_version=$(curl --fail "${download_link}${feed_credential}" --verbose 2>&1)
+            specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" --verbose 2>&1)
 
             if [ $? -ne 0 ]; then
                 say_verbose "Error: ""$specific_product_version"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -650,6 +650,9 @@ get_specific_product_version() {
                 return 0
             fi
         fi
+        else
+         say_verbose "!!!!!!!!!!!!!! specific_product_version remains null"
+        fi
     done
     
     # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -637,7 +637,9 @@ get_specific_product_version() {
 
         if machine_has "curl"
         then
+            say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
             specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
+            say_verbose "!!!!!!!!!!!!!! BEFORE $? = 0"
             if [ $? = 0 ]; then
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1253,7 +1253,9 @@ generate_regular_links() {
 
     # Add link info to arrays
     download_links+=($download_link)
+    say_verbose "!!!!!! Download link $download_link PRIMARY"
     specific_versions+=($specific_version)
+    say_verbose "!!!!!! Specific version $specific_version PRIMARY"
     effective_versions+=($effective_version)
     say_verbose "!!!!!! Effective version $effective_version PRIMARY"
     link_types+=("primary")
@@ -1264,7 +1266,9 @@ generate_regular_links() {
         say_verbose "Constructed legacy named payload URL: $legacy_download_link"
     
         download_links+=($legacy_download_link)
+        say_verbose "!!!!!! Download link $legacy_download_link LEGACY"
         specific_versions+=($specific_version)
+        say_verbose "!!!!!! Specific version $specific_version LEGACY"
         effective_versions+=($effective_version)
             say_verbose "!!!!!! Effective version $effective_version  LEGACY"
         link_types+=("legacy")

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -640,7 +640,7 @@ get_specific_product_version() {
         if machine_has "curl"
         then
             say_verbose "!!! Before CURL invocation ${download_link}"
-            specific_product_version="$get_specific_product_version_from_curl "$download_link""
+            specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
             if [ $? = 0 ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -649,7 +649,6 @@ get_specific_product_version() {
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi
-        fi
         else
          say_verbose "!!!!!!!!!!!!!! specific_product_version remains null"
         fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -627,7 +627,7 @@ get_specific_product_version() {
         local package_download_link="$3"
     fi
     local specific_product_version=null
-    say_verbose "!!! before dl"
+
     # Try to get the version number, using the productVersion.txt file located next to the installer file.
     local download_links=($(get_specific_product_version_url "$azure_feed" "$specific_version" true "$package_download_link")
         $(get_specific_product_version_url "$azure_feed" "$specific_version" false "$package_download_link"))
@@ -641,11 +641,11 @@ get_specific_product_version() {
         then
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
-            say_verbose "!!! After CURL invocation"
-            # if [ $? = 0 ]; then
-            #     echo "${specific_product_version//[$'\t\r\n']}"
-            #     return 0
-            # fi
+            if [ $? = 0 ]; then
+                say_verbose "!!! After CURL invocation"
+                echo "${specific_product_version//[$'\t\r\n']}"
+                return 0
+            fi
         elif machine_has "wget"
         then
             specific_product_version=$(wget -qO- "${download_link}${feed_credential}" 2>&1)

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -667,7 +667,7 @@ get_specific_product_version_from_curl() {
 
     local download_link="$1"
     local specific_product_version=""
-     if [ -z "$download_link" ]; then
+     if [ !-z "$download_link" ]; then
         say_verbose "!!!!!!!!!Before curl call ${download_link}${feed_credential}"
         specific_product_version=$(curl -s --fail "${download_link}${feed_credential}" 2>&1)
         say_verbose "!!!!!!!!!specific_product_version ${specific_product_version}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,10 +642,10 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ $? = 0 ]; then
-                echo "${specific_product_version//[$'\t\r\n']}"
-                return 0
-            fi
+            # if [ $? = 0 ]; then
+            #     echo "${specific_product_version//[$'\t\r\n']}"
+            #     return 0
+            # fi
         elif machine_has "wget"
         then
             specific_product_version=$(wget -qO- "${download_link}${feed_credential}" 2>&1)
@@ -666,7 +666,6 @@ get_specific_product_version() {
 # args:
 # download link - $1
 get_specific_product_version_from_curl() {
-
     eval $invocation
 
     local download_link="$1"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,7 +642,7 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             say_verbose "!!! After CURL invocation"
-            if [ !-z "$specific_product_version" ]; then
+            if [ [$? = 0 && !-z "$specific_product_version"] ]; then
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -642,9 +642,12 @@ get_specific_product_version() {
             say_verbose "!!! Before CURL invocation ${download_link}"
             specific_product_version="$(get_specific_product_version_from_curl "$download_link")"
             if [ $? = 0 ]; then
-                say_verbose "!!! After CURL invocation"
+                say_verbose "!!! After SUCCESSUL CURL invocation"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0
+            else 
+                say_verbose "!!! After FAILED CURL invocation"
+                break
             fi
         elif machine_has "wget"
         then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -637,11 +637,11 @@ get_specific_product_version() {
 
         if machine_has "curl"
         then
-            say_verbose "!!!!!!!!!!!!!! dl ${download_link}"
+            say_verbose "!!!!!!!!!!!!!! dl ${download_link} fc ${feed_credential}"
             specific_product_version=$(curl --fail "${download_link}${feed_credential}" --verbose 2>&1)
-            if [ $? -ne 0 ] ; then
-                say_verbose "Error: ${specific_product_version}"
-            else then
+
+            if [ $? -ne 0 ]; then
+                say_verbose "Error: ""$specific_product_version"
                 say_verbose "!!!!!!!!!!!!!! curl ${specific_product_version//[$'\t\r\n']}"
                 echo "${specific_product_version//[$'\t\r\n']}"
                 return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1173,7 +1173,7 @@ generate_download_links() {
     say_verbose "Generated ${#download_links[@]} links."
     for link_index in ${!download_links[@]}
     do
-        say_verbose "Link $link_index: ${link_types[$link_index]}, ${effective_versions[$link_index]}, ${download_links[$link_index]}"
+        say_verbose "Link $link_index: ${link_types[$link_index]}, ${download_links[$link_index]}"
     done
 }
 
@@ -1253,11 +1253,11 @@ generate_regular_links() {
 
     # Add link info to arrays
     download_links+=($download_link)
-    say_verbose "!!!!!! Download link $download_link PRIMARY"
+    say_verbose "!!!!!! Download link $download_link PRIMARY!"
     specific_versions+=($specific_version)
-    say_verbose "!!!!!! Specific version $specific_version PRIMARY"
+    say_verbose "!!!!!! Specific version $specific_version PRIMARY!"
     effective_versions+=($effective_version)
-    say_verbose "!!!!!! Effective version $effective_version PRIMARY"
+    say_verbose "!!!!!! Effective version $effective_version PRIMARY!"
     link_types+=("primary")
 
     legacy_download_link="$(construct_legacy_download_link "$feed" "$channel" "$normalized_architecture" "$specific_version")" || valid_legacy_download_link=false
@@ -1266,11 +1266,11 @@ generate_regular_links() {
         say_verbose "Constructed legacy named payload URL: $legacy_download_link"
     
         download_links+=($legacy_download_link)
-        say_verbose "!!!!!! Download link $legacy_download_link LEGACY"
+        say_verbose "!!!!!! Download link $legacy_download_link LEGACY!"
         specific_versions+=($specific_version)
-        say_verbose "!!!!!! Specific version $specific_version LEGACY"
+        say_verbose "!!!!!! Specific version $specific_version LEGACY!"
         effective_versions+=($effective_version)
-            say_verbose "!!!!!! Effective version $effective_version  LEGACY"
+            say_verbose "!!!!!! Effective version $effective_version  LEGACY!"
         link_types+=("legacy")
     else
         legacy_download_link=""


### PR DESCRIPTION
fix bashscript for run in `sudo sh` environment.
Guideline for fix: [SC2181](https://github.com/koalaman/shellcheck/wiki/SC2181)

Install-scripts log with applied changes

```
ykovalova@NETUXs-MacBook-Pro ~ % sudo sh dotnet-install.sh --version "6.0.200" --install-dir "/Users/runner/hostedtoolcache888/dotnet" --verbose
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Calling: machine_has curl
dotnet-install: Calling: calculate_vars
dotnet-install: Calling: get_normalized_architecture_from_architecture <auto>
dotnet-install: Calling: get_machine_architecture
dotnet-install: Normalized architecture: 'x64'.
dotnet-install: Calling: get_normalized_os
dotnet-install: Calling: get_current_os_name
dotnet-install: Normalized OS: 'osx'.
dotnet-install: Calling: get_normalized_quality
dotnet-install: Normalized quality: ''.
dotnet-install: Calling: get_normalized_channel LTS
dotnet-install: Normalized channel: 'LTS'.
dotnet-install: Calling: get_normalized_product
dotnet-install: Normalized product: 'dotnet-sdk'.
dotnet-install: Calling: resolve_installation_path /Users/runner/hostedtoolcache888/dotnet
dotnet-install: InstallRoot: '/Users/runner/hostedtoolcache888/dotnet'.
dotnet-install: Calling: get_specific_version_from_version https://dotnetcli.azureedge.net/dotnet LTS x64 6.0.200
dotnet-install: Calling: get_specific_product_version https://dotnetcli.azureedge.net/dotnet 6.0.200
dotnet-install: Calling: get_specific_product_version_url https://dotnetcli.azureedge.net/dotnet 6.0.200 true
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url https://dotnetcli.azureedge.net/dotnet 6.0.200 false
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: specific_version=6.0.200
dotnet-install: Calling: construct_download_link https://dotnetcli.azureedge.net/dotnet LTS x64 6.0.200 osx
dotnet-install: Calling: get_specific_product_version https://dotnetcli.azureedge.net/dotnet 6.0.200
dotnet-install: Calling: get_specific_product_version_url https://dotnetcli.azureedge.net/dotnet 6.0.200 true
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url https://dotnetcli.azureedge.net/dotnet 6.0.200 false
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: Constructed primary named payload URL: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Calling: construct_legacy_download_link https://dotnetcli.azureedge.net/dotnet LTS x64 6.0.200
dotnet-install: Calling: get_legacy_os_name
dotnet-install: Constructed legacy named payload URL: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-dev-osx-x64.6.0.200.tar.gz
dotnet-install: Calling: is_dotnet_package_installed /Users/runner/hostedtoolcache888/dotnet sdk 6.0.200
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet sdk
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet
dotnet-install: combine_paths: child_path=sdk
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet/sdk 6.0.200
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet/sdk
dotnet-install: combine_paths: child_path=6.0.200
dotnet-install: is_dotnet_package_installed: dotnet_package_path=/Users/runner/hostedtoolcache888/dotnet/sdk/6.0.200
dotnet-install: Calling: get_specific_version_from_version https://dotnetbuilds.azureedge.net/public LTS x64 6.0.200
dotnet-install: Calling: get_specific_product_version https://dotnetbuilds.azureedge.net/public 6.0.200
dotnet-install: Calling: get_specific_product_version_url https://dotnetbuilds.azureedge.net/public 6.0.200 true
dotnet-install: Constructed productVersion link: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url https://dotnetbuilds.azureedge.net/public 6.0.200 false
dotnet-install: Constructed productVersion link: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: Failed to get the version using productVersion.txt file. Download link will be parsed instead.
dotnet-install: Calling: get_product_specific_version_from_download_link  6.0.200
dotnet-install: specific_version=6.0.200
dotnet-install: Calling: construct_download_link https://dotnetbuilds.azureedge.net/public LTS x64 6.0.200 osx
dotnet-install: Calling: get_specific_product_version https://dotnetbuilds.azureedge.net/public 6.0.200
dotnet-install: Calling: get_specific_product_version_url https://dotnetbuilds.azureedge.net/public 6.0.200 true
dotnet-install: Constructed productVersion link: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url https://dotnetbuilds.azureedge.net/public 6.0.200 false
dotnet-install: Constructed productVersion link: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: Failed to get the version using productVersion.txt file. Download link will be parsed instead.
dotnet-install: Calling: get_product_specific_version_from_download_link  6.0.200
dotnet-install: Constructed primary named payload URL: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Calling: construct_legacy_download_link https://dotnetbuilds.azureedge.net/public LTS x64 6.0.200
dotnet-install: Calling: get_legacy_os_name
dotnet-install: Constructed legacy named payload URL: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/dotnet-dev-osx-x64.6.0.200.tar.gz
dotnet-install: Calling: is_dotnet_package_installed /Users/runner/hostedtoolcache888/dotnet sdk 6.0.200
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet sdk
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet
dotnet-install: combine_paths: child_path=sdk
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet/sdk 6.0.200
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet/sdk
dotnet-install: combine_paths: child_path=6.0.200
dotnet-install: is_dotnet_package_installed: dotnet_package_path=/Users/runner/hostedtoolcache888/dotnet/sdk/6.0.200
dotnet-install: Generated 4 links.
dotnet-install: Link 0: primary, 6.0.200, https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Link 1: legacy, 6.0.200, https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-dev-osx-x64.6.0.200.tar.gz
dotnet-install: Link 2: primary, 6.0.200, https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Link 3: legacy, 6.0.200, https://dotnetbuilds.azureedge.net/public/Sdk/6.0.200/dotnet-dev-osx-x64.6.0.200.tar.gz
dotnet-install: Calling: install_dotnet
dotnet-install: Zip path: /tmp/dotnet.NEBHSEZGx
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Calling: download https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz /tmp/dotnet.NEBHSEZGx
dotnet-install: Calling: machine_has curl
dotnet-install: Calling: downloadcurl https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz /tmp/dotnet.NEBHSEZGx
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.200/dotnet-sdk-6.0.200-osx-x64.tar.gz
dotnet-install: Calling: extract_dotnet_package /tmp/dotnet.NEBHSEZGx /Users/runner/hostedtoolcache888/dotnet
dotnet-install: Calling: copy_files_or_dirs_from_list /tmp/dotnet.LsJDZ8GfB /Users/runner/hostedtoolcache888/dotnet false
dotnet-install: Calling: get_current_os_name
dotnet-install: Calling: copy_files_or_dirs_from_list /tmp/dotnet.LsJDZ8GfB /Users/runner/hostedtoolcache888/dotnet true
dotnet-install: Calling: get_current_os_name
dotnet-install: Temporary zip file /tmp/dotnet.NEBHSEZGx was removed
dotnet-install: Checking installation: version = 6.0.200
dotnet-install: Calling: is_dotnet_package_installed /Users/runner/hostedtoolcache888/dotnet sdk 6.0.200
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet sdk
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet
dotnet-install: combine_paths: child_path=sdk
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet/sdk 6.0.200
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet/sdk
dotnet-install: combine_paths: child_path=6.0.200
dotnet-install: is_dotnet_package_installed: dotnet_package_path=/Users/runner/hostedtoolcache888/dotnet/sdk/6.0.200
dotnet-install: Calling: combine_paths /Users/runner/hostedtoolcache888/dotnet
dotnet-install: combine_paths: root_path=/Users/runner/hostedtoolcache888/dotnet
dotnet-install: combine_paths: child_path=
dotnet-install: Calling: get_absolute_path /Users/runner/hostedtoolcache888/dotnet/
dotnet-install: Adding to current process PATH: `/Users/runner/hostedtoolcache888/dotnet`. Note: This change will be visible only when sourcing script.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://docs.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
```
