### PR TITLE
Fix wget path on Alpine

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -926,7 +926,7 @@ get_http_header_wget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    wget -h 2>&1 | grep "xwaitretry" >null && wget -h 2>&1 | grep "connect-timeout" >null
+    wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null
     if [ $? = 0 ]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi
@@ -1042,7 +1042,7 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    wget -h 2>&1 | grep "xwaitretry" >null && wget -h 2>&1 | grep "connect-timeout" >null
+    wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null
     if [ $? = 0 ]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -921,9 +921,15 @@ get_http_header_wget() {
     local remote_path="$1"
     local disable_feed_credential="$2"
     local wget_options="-q -S --spider --tries 5 "
-    # Store options that aren't supported on all wget implementations separately.
-    local wget_options_extra="--waitretry 2 --connect-timeout 15 "
+
+    local wget_options_extra=''
     local wget_result=''
+
+    # Test for options that aren't supported on all wget implementations.
+    wget -h 2>&1 | grep "xwaitretry" >nul && wget -h 2>&1 | grep "connect-timeout" >nul
+    if [ $? = 0 ]; then
+        wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    fi
 
     remote_path_with_credential="$remote_path"
     if [ "$disable_feed_credential" = false ]; then
@@ -933,7 +939,7 @@ get_http_header_wget() {
     wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
     wget_result=$?
 
-    if [[ $wget_result == 2  ]] || [[ $wget_result == 1 ]]; then
+    if [[ $wget_result == 1  ]] || [[ $wget_result == 2 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
         say_verbose "wget parsing failed. trying again with fewer options.."
         wget $wget_options "$remote_path_with_credential" 2>&1
@@ -1031,9 +1037,15 @@ downloadwget() {
     # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
     local remote_path_with_credential="${remote_path}${feed_credential}"
     local wget_options="--tries 20 "
-    # Store options that aren't supported on all wget implementations separately.
-    local wget_options_extra="--waitretry 2 --connect-timeout 15 "
+
+    local wget_options_extra=''
     local wget_result=''
+
+    # Test for options that aren't supported on all wget implementations.
+    wget -h 2>&1 | grep "xwaitretry" >nul && wget -h 2>&1 | grep "connect-timeout" >nul
+    if [ $? = 0 ]; then
+        wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    fi
 
     if [ -z "$out_path" ]; then
         wget -q $wget_options $wget_options_extra -O - "$remote_path_with_credential" 2>&1
@@ -1043,7 +1055,7 @@ downloadwget() {
         wget_result=$?
     fi
 
-    if [[ $wget_result == 2  ]] || [[ $wget_result == 1 ]]; then
+    if [[ $wget_result == 1  ]] || [[ $wget_result == 2 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
         say_verbose "wget parsing failed. trying again with fewer options.."
         if [ -z "$out_path" ]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -933,8 +933,9 @@ get_http_header_wget() {
     wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
     wget_result=$?
 
-    if [[ $wget_result == 2 ]]; then
+    if [[ $wget_result == 2  ]] || [[ $wget_result == 1 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
+        say_verbose "wget parsing failed. trying again with fewer options.."
         wget $wget_options "$remote_path_with_credential" 2>&1
         return $?
     fi
@@ -1042,8 +1043,9 @@ downloadwget() {
         wget_result=$?
     fi
 
-    if [[ $wget_result == 2 ]]; then
+    if [[ $wget_result == 2  ]] || [[ $wget_result == 1 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
+        say_verbose "wget parsing failed. trying again with fewer options.."
         if [ -z "$out_path" ]; then
             wget -q $wget_options -O - "$remote_path_with_credential" 2>&1
             wget_result=$?

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -925,7 +925,7 @@ get_http_header_wget() {
     local wget_options_extra=''
 
     # Test for options that aren't supported on all wget implementations.
-    if ! wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
+    if wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
         say 'wget extra options are unavailable for this environment'
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
@@ -1034,7 +1034,7 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    if ! wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
+    if wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
         say 'wget extra options are unavaiable for this environment'
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -925,8 +925,8 @@ get_http_header_wget() {
     local wget_options_extra=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ] then
-        say 'wget extra options are unavailable for this environment'
+    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]; then
+        say "wget extra options are unavailable for this environment"
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi
@@ -1034,8 +1034,8 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ] then
-        say 'wget extra options are unavaiable for this environment'
+    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]; then
+        say "wget extra options are unavaiable for this environment"
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -923,11 +923,11 @@ get_http_header_wget() {
     local wget_options="-q -S --spider --tries 5 "
 
     local wget_options_extra=''
-    local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null
-    if [ $? = 0 ]; then
+    if ! wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
+        say 'wget extra options are unavaiable for this environment'
+    else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi
 
@@ -937,16 +937,8 @@ get_http_header_wget() {
     fi
 
     wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
-    wget_result=$?
 
-    if [[ $wget_result == 1 ]] || [[ $wget_result == 2 ]]; then
-        # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
-        say_verbose "wget parsing failed. trying again with fewer options.."
-        wget $wget_options "$remote_path_with_credential" 2>&1
-        return $?
-    fi
-
-    return $wget_result
+    return $?
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -925,10 +925,10 @@ get_http_header_wget() {
     local wget_options_extra=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [[ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]]; then
-        say "wget extra options are unavailable for this environment"
-    else
+    if [[ $(wget -h 2>&1 | grep -E 'waitretry|connect-timeout') ]]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    else
+        say "wget extra options are unavailable for this environment"
     fi
 
     remote_path_with_credential="$remote_path"
@@ -1034,10 +1034,10 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [[ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]]; then
-        say "wget extra options are unavaiable for this environment"
-    else
+    if [[ $(wget -h 2>&1 | grep -E 'waitretry|connect-timeout') ]]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    else
+        say "wget extra options are unavailable for this environment"
     fi
 
     if [ -z "$out_path" ]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -926,7 +926,7 @@ get_http_header_wget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    wget -h 2>&1 | grep "xwaitretry" >nul && wget -h 2>&1 | grep "connect-timeout" >nul
+    wget -h 2>&1 | grep "xwaitretry" >null && wget -h 2>&1 | grep "connect-timeout" >null
     if [ $? = 0 ]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi
@@ -939,7 +939,7 @@ get_http_header_wget() {
     wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
     wget_result=$?
 
-    if [[ $wget_result == 1  ]] || [[ $wget_result == 2 ]]; then
+    if [[ $wget_result == 1 ]] || [[ $wget_result == 2 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
         say_verbose "wget parsing failed. trying again with fewer options.."
         wget $wget_options "$remote_path_with_credential" 2>&1
@@ -1042,7 +1042,7 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    wget -h 2>&1 | grep "xwaitretry" >nul && wget -h 2>&1 | grep "connect-timeout" >nul
+    wget -h 2>&1 | grep "xwaitretry" >null && wget -h 2>&1 | grep "connect-timeout" >null
     if [ $? = 0 ]; then
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
     fi
@@ -1055,7 +1055,7 @@ downloadwget() {
         wget_result=$?
     fi
 
-    if [[ $wget_result == 1  ]] || [[ $wget_result == 2 ]]; then
+    if [[ $wget_result == 1 ]] || [[ $wget_result == 2 ]]; then
         # Parsing of the command has failed. Exclude potentially unrecognized options and retry.
         say_verbose "wget parsing failed. trying again with fewer options.."
         if [ -z "$out_path" ]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -925,7 +925,7 @@ get_http_header_wget() {
     local wget_options_extra=''
 
     # Test for options that aren't supported on all wget implementations.
-    if wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
+    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ] then
         say 'wget extra options are unavailable for this environment'
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
@@ -1034,7 +1034,7 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    if wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null; then
+    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ] then
         say 'wget extra options are unavaiable for this environment'
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -936,7 +936,9 @@ get_http_header_wget() {
         remote_path_with_credential+="$feed_credential"
     fi
 
-    return wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
+    wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
+
+    return $?
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -925,7 +925,7 @@ get_http_header_wget() {
     local wget_options_extra=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]; then
+    if [[ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]]; then
         say "wget extra options are unavailable for this environment"
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "
@@ -1034,7 +1034,7 @@ downloadwget() {
     local wget_result=''
 
     # Test for options that aren't supported on all wget implementations.
-    if [ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]; then
+    if [[ $(wget -h 2>&1 | grep "waitretry" >/dev/null && wget -h 2>&1 | grep "connect-timeout" >/dev/null;) != 0 ]]; then
         say "wget extra options are unavaiable for this environment"
     else
         wget_options_extra="--waitretry 2 --connect-timeout 15 "


### PR DESCRIPTION
Fix #259 

1. Test `wget -h` output for the two extra parameters we want to use, and only attempt to use them if we see them there. Pipe to /dev/null so that there's no visible output.
2. Leave the fallback path in to reduce risk. However BusyBox wget sets exit code 1 when there are unexpected parameters and GNU wget returns 2. Fix this path by checking for either.

Tested on Alpine and Ubuntu (forcing the wget path). Verified it works, and that on Ubuntu it does use the extra wget parameters.
