### PR TITLE
Fix check if version and quality are not specified

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1190,7 +1190,7 @@ generate_akams_links() {
     local valid_aka_ms_link=true;
 
     normalized_version="$(to_lowercase "$version")"
-    if [[ "$normalized_version" != "latest" ]] && [ -n "$normalized_quality" ]; then
+    if [[ -z "$normalized_version" && -z "$normalized_quality" ]]; then
         say_err "Either Quality or Version option has to be specified. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
         return 1
     fi


### PR DESCRIPTION
Fix #285

This PR https://github.com/dotnet/install-scripts/pull/278 introduced a check and based on the error message it seems to be validating that at least --version or --quality is specified.  The current `if` statement doesn't do this correctly, it's comparing only if `--version latest` isn't specified and `-n` does the opposite of checking if `--quality` is empty.

Used https://linuxhint.com/testing_strings_bash_z_n as a resource on the difference of now `-n` and `-z` works for bash `if` statement for strings.  Where `-n` returns true if the string is NOT null, and `-z` returns true if the string IS null.

Note that are other usage of `-n` in the script and I didn't validate if those are correct.  I only tested this change locally that the way our CI uses dotnet-install.sh with both --version and --quality specified works.