### PR TITLE
revert 286 + extend test coverage

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1109,7 +1109,7 @@ $feeds = Get-Feeds-To-Use
 $DownloadLinks = @()
 
 if ($Version.ToLowerInvariant() -ne "latest" -and -not [string]::IsNullOrEmpty($Quality)) {
-    throw "Either Quality or Version option has to be specified. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
+    throw "Quality and Version options are not allowed to be specified simultaneously. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
 }
 
 # aka.ms links can only be used if the user did not request a specific version via the command line or a global.json file.

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1190,7 +1190,7 @@ generate_akams_links() {
     local valid_aka_ms_link=true;
 
     normalized_version="$(to_lowercase "$version")"
-    if [[ -z "$normalized_version" && -z "$normalized_quality" ]]; then
+    if [[ "$normalized_version" != "latest" ]] && [ -n "$normalized_quality" ]; then
         say_err "Either Quality or Version option has to be specified. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
         return 1
     fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1191,7 +1191,7 @@ generate_akams_links() {
 
     normalized_version="$(to_lowercase "$version")"
     if [[ "$normalized_version" != "latest" ]] && [ -n "$normalized_quality" ]; then
-        say_err "Either Quality or Version option has to be specified. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
+        say_err "Quality and Version options are not allowed to be specified simultaneously. See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for details."
         return 1
     fi
 

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using FluentAssertions;
+using Install_Scripts.Test.Utils;
 using Microsoft.NET.TestFramework.Assertions;
 using System;
 using System.Collections.Generic;
@@ -296,6 +297,23 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().NotHaveStdOutContaining("Repeatable invocation:");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
             commandResult.Should().NotHaveStdErrContainingIgnoreCase(feedCredentials);
+        }
+
+        [Theory]
+        [InlineData("7.0.1", Quality.Daily)]
+        [InlineData("6.0.1", Quality.Signed)]
+        public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
+        {
+            string feedCredentials = Guid.NewGuid().ToString();
+            var args = new[] { "-dryrun", "-version", version, "-quality", quality.ToString(),  "-feedCredential", feedCredentials };
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Fail();
+            commandResult.Should().HaveStdErrContaining("Quality and Version options are not allowed to be specified simultaneously.");
         }
 
         [Fact]

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using FluentAssertions;
-using Install_Scripts.Test.Utils;
 using Microsoft.NET.TestFramework.Assertions;
 using System;
 using System.Collections.Generic;
@@ -297,23 +296,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().NotHaveStdOutContaining("Repeatable invocation:");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
             commandResult.Should().NotHaveStdErrContainingIgnoreCase(feedCredentials);
-        }
-
-        [Theory]
-        [InlineData("7.0.1", Quality.Daily)]
-        [InlineData("6.0.1", Quality.Signed)]
-        public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
-        {
-            string feedCredentials = Guid.NewGuid().ToString();
-            var args = new[] { "-dryrun", "-version", version, "-quality", quality.ToString(),  "-feedCredential", feedCredentials };
-
-            var commandResult = CreateInstallCommand(args)
-                            .CaptureStdOut()
-                            .CaptureStdErr()
-                            .Execute();
-
-            commandResult.Should().Fail();
-            commandResult.Should().HaveStdErrContaining("Quality and Version options are not allowed to be specified simultaneously.");
         }
 
         [Fact]

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -600,8 +600,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("6.0.1", Quality.Signed)]
         public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
         {
-            string feedCredentials = Guid.NewGuid().ToString();
-            var args = new[] { "-dryrun", "-version", version, "-quality", quality.ToString(), "-feedCredential", feedCredentials };
+            var args = GetInstallScriptArgs(null, null, quality.ToString(), _sdkInstallationDirectory, version);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -612,6 +611,39 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().HaveStdErrContaining("Quality and Version options are not allowed to be specified simultaneously.");
             commandResult.Should().NotHaveStdOutContaining("Installation finished");
         }
+
+
+        [Theory]
+        [InlineData(null, Quality.Signed)]
+        [InlineData("6.0.1", null)]
+        public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
+        {
+            // Run install script to download and install.
+            var args = GetInstallScriptArgs(null, null, quality?.ToString(), _sdkInstallationDirectory, version);
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().HaveStdOutContaining("Installation finished");
+            commandResult.Should().NotHaveStdErr();
+            commandResult.Should().Pass();
+        }
+
+        [Fact]
+        public void WhenNoArgsWereSpecified()
+        {
+            var commandResult = CreateInstallCommand(Enumerable.Empty<string>())
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().HaveStdOutContaining("Installation finished");
+            commandResult.Should().NotHaveStdErr();
+            commandResult.Should().Pass();
+        }
+
 
         private static IEnumerable<string> GetInstallScriptArgs(
             string? channel, 

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -615,7 +615,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [InlineData(null, Quality.Signed)]
-        [InlineData("7.0.100-preview.5", null)]
+        [InlineData("6.0.301", null)]
         public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
         {
             // Run install script to download and install.

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -615,7 +615,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [InlineData(null, Quality.Signed)]
-        [InlineData("6.0.1", null)]
+        [InlineData("7.0.1", null)]
         public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
         {
             // Run install script to download and install.

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -615,7 +615,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [InlineData(null, Quality.Signed)]
-        [InlineData("7.0.1", null)]
+        [InlineData("7.0.100-preview.5", null)]
         public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
         {
             // Run install script to download and install.

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -600,7 +600,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("6.0.1", Quality.Signed)]
         public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
         {
-            var args = GetInstallScriptArgs(null, null, quality.ToString(), _sdkInstallationDirectory, version);
+            var args = GetInstallScriptArgs(null, null, quality.ToString(), _sdkInstallationDirectory, version: version);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()
@@ -619,7 +619,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
         {
             // Run install script to download and install.
-            var args = GetInstallScriptArgs(null, null, quality?.ToString(), _sdkInstallationDirectory, version);
+            var args = GetInstallScriptArgs(null, null, quality?.ToString(), _sdkInstallationDirectory, version: version);
 
             var commandResult = CreateInstallCommand(args)
                             .CaptureStdOut()

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -595,6 +595,24 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredential);
         }
 
+        [Theory]
+        [InlineData("7.0.1", Quality.Daily)]
+        [InlineData("6.0.1", Quality.Signed)]
+        public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
+        {
+            string feedCredentials = Guid.NewGuid().ToString();
+            var args = new[] { "-dryrun", "-version", version, "-quality", quality.ToString(), "-feedCredential", feedCredentials };
+
+            var commandResult = CreateInstallCommand(args)
+                            .CaptureStdOut()
+                            .CaptureStdErr()
+                            .Execute();
+
+            commandResult.Should().Fail();
+            commandResult.Should().HaveStdErrContaining("Quality and Version options are not allowed to be specified simultaneously.");
+            commandResult.Should().NotHaveStdOutContaining("Installation finished");
+        }
+
         private static IEnumerable<string> GetInstallScriptArgs(
             string? channel, 
             string? runtime,

--- a/tests/Install-Scripts.Test/Utils/Quality.cs
+++ b/tests/Install-Scripts.Test/Utils/Quality.cs
@@ -3,7 +3,7 @@
 namespace Install_Scripts.Test.Utils
 {
     [Flags]
-    public enum Quality
+    enum Quality
     {
         None = 0,
         Daily = 1,

--- a/tests/Install-Scripts.Test/Utils/Quality.cs
+++ b/tests/Install-Scripts.Test/Utils/Quality.cs
@@ -3,7 +3,7 @@
 namespace Install_Scripts.Test.Utils
 {
     [Flags]
-    enum Quality
+    public enum Quality
     {
         None = 0,
         Daily = 1,


### PR DESCRIPTION
revert 286 according to https://github.com/dotnet/install-scripts/issues/287, improve error message for case when quality and version are both specified, extend test coverage

Documentation is also updated 
[https://github.com/dotnet/docs/pull/30005](https://github.com/dotnet/docs/pull/30005)