### PR TITLE
Support s390x

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -306,6 +306,10 @@ get_machine_architecture() {
             echo "arm64"
             return 0
             ;;
+        s390x)
+            echo "s390x"
+            return 0
+            ;;
         esac
     fi
 
@@ -337,6 +341,10 @@ get_normalized_architecture_from_architecture() {
             ;;
         arm64)
             echo "arm64"
+            return 0
+            ;;
+        s390x)
+            echo "s390x"
             return 0
             ;;
     esac
@@ -1587,7 +1595,7 @@ do
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
             echo "      --arch,-Architecture,-Arch"
-            echo "          Possible values: x64, arm, and arm64"
+            echo "          Possible values: x64, arm, arm64 and s390x"
             echo "  --os <system>                    Specifies operating system to be used when selecting the installer."
             echo "          Overrides the OS determination approach used by the script. Supported values: osx, linux, linux-musl, freebsd, rhel.6."
             echo "          In case any other value is provided, the platform will be determined by the script based on machine configuration."


### PR DESCRIPTION
s390x support was introduced in .NET 6, and even though the
corresponding binaries are not distributed via
dotnetcli.azureedge.net, it is possible to get them from a custom feed.
When preparing a tarball for the source build, one could use this as
follows:

```
./build.sh -runtimesourcefeed /path/to/feed /p:DotNetRuntimeSourceFeed=/path/to/feed ...
```