### PR TITLE
add support for ppc64le in install-script

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -310,6 +310,10 @@ get_machine_architecture() {
             echo "s390x"
             return 0
             ;;
+        ppc64le)
+            echo "ppc64le"
+            return 0
+            ;;
         esac
     fi
 
@@ -345,6 +349,10 @@ get_normalized_architecture_from_architecture() {
             ;;
         s390x)
             echo "s390x"
+            return 0
+            ;;
+        ppc64le)
+            echo "ppc64le"
             return 0
             ;;
     esac
@@ -1651,7 +1659,7 @@ do
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
             echo "      --arch,-Architecture,-Arch"
-            echo "          Possible values: x64, arm, arm64 and s390x"
+            echo "          Possible values: x64, arm, arm64, s390x and ppc64le"
             echo "  --os <system>                    Specifies operating system to be used when selecting the installer."
             echo "          Overrides the OS determination approach used by the script. Supported values: osx, linux, linux-musl, freebsd, rhel.6."
             echo "          In case any other value is provided, the platform will be determined by the script based on machine configuration."


### PR DESCRIPTION
.NET 7 supports ppc64le architecture. Microsoft does not generate and uploads binaries at dotnetcli.azureedge.net as it is community supported architecture. But it is possible to get them from a custom feed.
When preparing a tarball for the source build, one could use this as follows:

`./build.sh -runtimesourcefeed /path/to/feed /p:DotNetRuntimeSourceFeed=/path/to/feed ...`

Note: eng/common folder is yet not in sync with latest arcade. Issue https://github.com/dotnet/install-scripts/issues/345 has been opened for the same.