### PR TITLE
Add possibility to output an env. variables with installed by the script .NET product version

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1116,6 +1116,19 @@ function Prepare-Install-Directory {
     }
 }
 
+function Set-Informational-Env-Variable([string]$assetName, [string]$version ) {
+    $envVariablePostfix = $null
+    if ($assetName.ToLower().Contains("runtime")) {
+        $envVariablePostfix = "RUNTIME"
+    }
+    else {
+        $envVariablePostfix = "SDK"
+    }
+    $envVariableName = "INSTALLED_DOTNET_$($envVariablePostfix)"
+    [Environment]::SetEnvironmentVariable($envVariableName, $version)
+    Say-Verbose "Informational environment variable $envVariableName is set to $version"
+}
+
 Say-Verbose "Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
 Say-Verbose "- The SDK needs to be installed without user interaction and without admin rights."
 Say-Verbose "- The SDK installation doesn't need to persist across multiple CI runs."
@@ -1164,6 +1177,7 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
             {
                 Say "$assetName with version '$EffectiveVersion' is already installed."
                 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                Set-Informational-Env-Variable $assetName $EffectiveVersion
                 return
             }
         }
@@ -1194,6 +1208,7 @@ if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count)
                 {
                     Say "$assetName with version '$EffectiveVersion' is already installed."
                     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                    Set-Informational-Env-Variable $assetName $EffectiveVersion
                     return
                 }
             }
@@ -1297,3 +1312,4 @@ Say "Note that the script does not resolve dependencies during installation."
 Say "To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies"
 Say "Installed version is $($DownloadedLink.effectiveVersion)"
 Say "Installation finished"
+Set-Informational-Env-Variable $assetName $DownloadedLink.effectiveVersion

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1124,7 +1124,7 @@ function Set-Informational-Env-Variable([string]$assetName, [string]$version ) {
     else {
         $envVariablePostfix = "SDK"
     }
-    $envVariableName = "INSTALLED_DOTNET_$($envVariablePostfix)"
+    $envVariableName = "DOTNET_INSTALL_SCRIPTS_$($envVariablePostfix)_LAST_INSTALLED_VERSION"
     [Environment]::SetEnvironmentVariable($envVariableName, $version)
     Say-Verbose "Informational environment variable $envVariableName is set to $version"
 }

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1429,7 +1429,7 @@ set_informational_env_variable() {
     else
         env_variable_postfix="SDK"
     fi
-    local env_variable_name="INSTALLED_DOTNET_${env_variable_postfix}"
+    local env_variable_name="DOTNET_INSTALL_SCRIPTS_${env_variable_postfix}_LAST_INSTALLED_VERSION"
     export "$env_variable_name=$version"
     say_verbose "Informational environment variable ${env_variable_name} is set to $version"
     return 0

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1289,6 +1289,7 @@ generate_akams_links() {
         #  Check if the SDK version is already installed.
         if [[ "$dry_run" != true ]] && is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
             say "$asset_name with version '$effective_version' is already installed."
+            set_informational_env_variable "$asset_name" "$effective_version"
             exit 0
         fi
 
@@ -1347,6 +1348,7 @@ generate_regular_links() {
     #  Check if the SDK version is already installed.
     if [[ "$dry_run" != true ]] && is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
         say "$asset_name with version '$effective_version' is already installed."
+        set_informational_env_variable "$asset_name" "$effective_version"
         exit 0
     fi
 }
@@ -1415,6 +1417,24 @@ calculate_vars() {
     get_feeds_to_use
 }
 
+# args:
+# asset_name - $1
+# version - $2
+set_informational_env_variable() {
+    local asset_name="$1"
+    local version="$2"
+    local env_variable_postfix=""
+    if [[ $(to_lowercase "$asset_name") == *"runtime"* ]]; then
+        env_variable_postfix="RUNTIME"
+    else
+        env_variable_postfix="SDK"
+    fi
+    local env_variable_name="INSTALLED_DOTNET_${env_variable_postfix}"
+    export "$env_variable_name=$version"
+    say_verbose "Informational environment variable ${env_variable_name} is set to $version"
+    return 0
+}
+
 install_dotnet() {
     eval $invocation
     local download_failed=false
@@ -1472,6 +1492,7 @@ install_dotnet() {
         say_verbose "Checking installation: version = $release_version"
         if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$release_version"; then
             say "Installed version is $effective_version"
+            set_informational_env_variable "$asset_name" "$effective_version"
             return 0
         fi
     fi
@@ -1480,6 +1501,7 @@ install_dotnet() {
     say_verbose "Checking installation: version = $effective_version"
     if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
         say "Installed version is $effective_version"
+        set_informational_env_variable "$asset_name" "$effective_version"
         return 0
     fi
 


### PR DESCRIPTION
**Description**:
In the scope of this PR, the function `Set-Informational-Env-Variable() / set_informational_env_variable()` was added both to the `powershell` and `bash` scripts. 

**Notes:**
While the Powershell script is working perfectly, the Bash script isn't as good. Setting env. variables in the parent shell is possible only using sourcing (source or dot command) but the Bash script contains a lot of exits. As soon as the script is executed in source mode and meets the exit() command the script closes the shell. If you could give me a hint how to workaround this bash "feature", it would be really nice!

**Related issue**:
https://github.com/dotnet/install-scripts/issues/360
