### PR TITLE
change diskspace check due to PS issues

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1100,17 +1100,24 @@ function Resolve-AssetName-And-RelativePath([string] $Runtime) {
 }
 
 function Prepare-Install-Directory {
+    $diskSpaceWarning = "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space.";
+    # this check is relevant for PS version >= 7, the result can be irrelevant for older versions. See https://github.com/PowerShell/PowerShell/issues/12442.
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        Say-Warning $diskSpaceWarning
+        return $null
+    }
+
     New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
     $installDrive = $((Get-Item $InstallRoot -Force).PSDrive.Name);
     $diskInfo = $null
-    try{
+    try {
         $diskInfo = Get-PSDrive -Name $installDrive
     }
-    catch{
-        Say-Warning "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space."
+    catch {
+        Say-Warning $diskSpaceWarning
     }
-    
+
     if ( ($null -ne $diskInfo) -and ($diskInfo.Free / 1MB -le 100)) {
         throw "There is not enough disk space on drive ${installDrive}:"
     }

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1101,7 +1101,7 @@ function Resolve-AssetName-And-RelativePath([string] $Runtime) {
 
 function Prepare-Install-Directory {
     $diskSpaceWarning = "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space.";
-    # this check is relevant for PS version >= 7, the result can be irrelevant for older versions. See https://github.com/PowerShell/PowerShell/issues/12442.
+
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         Say-Warning $diskSpaceWarning
         return $null
@@ -1118,6 +1118,7 @@ function Prepare-Install-Directory {
         Say-Warning $diskSpaceWarning
     }
 
+    # The check is relevant for PS version >= 7, the result can be irrelevant for older versions. See https://github.com/PowerShell/PowerShell/issues/12442.
     if ( ($null -ne $diskInfo) -and ($diskInfo.Free / 1MB -le 100)) {
         throw "There is not enough disk space on drive ${installDrive}:"
     }


### PR DESCRIPTION
## Fixes 
#374

## Solution
For older PS versions it is a known issue: 
[build.cmd error dotnet-install: There is not enough disk space on drive C · Issue #35301 · dotnet/runtime (github.com)](https://github.com/dotnet/runtime/issues/35301)

[Get-PSDrive C returns blank used/free disk space · Issue #12442 · PowerShell/PowerShell (github.com)](https://github.com/PowerShell/PowerShell/issues/12442)

This fix loosens the check for PS with versions < 7.