### PR TITLE
update severity level on disk space check operation

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1103,8 +1103,8 @@ function Prepare-Install-Directory {
     $diskSpaceWarning = "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space.";
 
     if ($PSVersionTable.PSVersion.Major -lt 7) {
-        Say-Warning $diskSpaceWarning
-        return $null
+        Say-Verbose $diskSpaceWarning
+        return
     }
 
     New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null


### PR DESCRIPTION
Fixes: https://github.com/dotnet/install-scripts/issues/374

Solution: the previous warning is chatty because most of the build machines have PS version < 7. 
Make it available in verbose mode.