### PR TITLE
Add logging for remote/local package sizes

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -181,10 +181,9 @@ function Get-Remote-File-Size($zipUri) {
         $response = Invoke-WebRequest -Uri $zipUri -Method Head
         $fileSize = $response.Headers["Content-Length"]
         if ((![string]::IsNullOrEmpty($fileSize))) {
-            $fileSizeBits = [long]$fileSize * 8
-            Say "Initial file $zipUri size is $fileSizeBits bits."
+            Say "Remote file $zipUri size is $fileSize bytes."
         
-            return $fileSizeBits
+            return $fileSize
         }
      
     }
@@ -891,20 +890,19 @@ function DownloadFile($Source, [string]$OutPath) {
         $Stream.CopyTo($File)
         $File.Close()
 
-        # Calculate the downloaded file size in bits
-        $fileSizeBytes = [long](Get-Item $OutPath).Length
-        $fileSizeBits = $fileSizeBytes * 8
-
-        # Log the downloaded file size in bits
-        Say "Downloaded file $Source size is $fileSizeBits bits."
+        $fileSize = [long](Get-Item $OutPath).Length
+        Say "Downloaded file $Source size is $fileSize bytes."
     }
     finally {
         if ($null -ne $Stream) {
             $Stream.Dispose()
         }
 
-        if ((![string]::IsNullOrEmpty($remoteFileSize)) -and $remoteFileSize -ne $fileSizeBits) {
-            Say "The remote and local file sizes are not equal."
+        if ((![string]::IsNullOrEmpty($remoteFileSize)) -and $remoteFileSize -ne $fileSize) {
+            Say "The remote and local file sizes are not equal. Remote file size is $remoteFileSize bytes and local size is $fileSize bytes. The local package may be corrupted."
+        }
+        else {
+            Say "The remote and local file sizes are equal."
         }
     }
 }

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -566,13 +566,16 @@ validate_remote_local_file_sizes()
     if [ -n "$file_size" ]; then
         say "Downloaded file size is $file_size bytes."
 
-        if [ -n "$remote_file_size" ] && [ "$file_size" != "$remote_file_size" ]; then
-            say "The remote and local file sizes are not equal. Remote file size is $remote_file_size bytes and local size is $file_size bytes. The local package may be corrupted."
-        else
-            say "The remote and local file sizes are equal."
+        if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
+            if [ "$file_size" != "$remote_file_size" ]; then
+                say "The remote and local file sizes are not equal. Remote file size is $remote_file_size bytes and local size is $file_size bytes. The local package may be corrupted."
+            else
+                say "The remote and local file sizes are equal."
+            fi
         fi
+        
     else
-        say "The downloaded package size can not be measured. The downloaded package may be corrupted."      
+        say "Either downloaded or local package size can not be measured. One of them may be corrupted."      
     fi 
 }
 
@@ -962,7 +965,7 @@ get_remote_file_size() {
         say "Remote file $zip_uri size is $file_size bytes."
         echo "$file_size"
     else
-        say_verbose "Content-Length header was not extacted for $zip_uri."
+        say_verbose "Content-Length header was not extracted for $zip_uri."
         echo ""
     fi
 }

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -555,7 +555,6 @@ validate_remote_local_file_sizes()
 
     local downloaded_file="$1"
     local remote_file_size="$2"
-    local file_size_bits=''
 
     local file_size=''
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -565,12 +564,12 @@ validate_remote_local_file_sizes()
     fi  
     
     if [ -n "$file_size" ]; then
-        file_size_bits="$(awk "BEGIN { print $file_size * 8 }")"
+        say "Downloaded file size is $file_size bytes."
 
-        say "Downloaded file size is $file_size_bits bits."
-
-        if [ -n "$remote_file_size" ] && [ "$remote_file_size" -ne "$file_size_bits" ]; then
-            say "The remote and local file sizes are not equal."
+        if [ -n "$remote_file_size" ] && [ "$file_size" != "$remote_file_size" ]; then
+            say "The remote and local file sizes are not equal. Remote file size is $remote_file_size bytes and local size is $file_size bytes. The local package may be corrupted."
+        else
+            say "The remote and local file sizes are equal."
         fi
     else
         say "The downloaded package size can not be measured. The downloaded package may be corrupted."      
@@ -960,11 +959,10 @@ get_remote_file_size() {
     fi
 
     if [ -n "$file_size" ]; then
-        remote_file_size_bits=$(awk "BEGIN { print $file_size * 8 }")
-        say "Initial file $zip_uri size is $remote_file_size_bits bits."
-        echo "$remote_file_size_bits"
+        say "Remote file $zip_uri size is $file_size bytes."
+        echo "$file_size"
     else
-        say_verbose "Initial file size was not received from request."
+        say_verbose "Content-Length header was not extacted for $zip_uri."
         echo ""
     fi
 }


### PR DESCRIPTION
Fixes: #382

Logging for file sizes is added for tracking corruption cases.

Checked manually on Windows/Mac machines