### PR TITLE
fix remote vs local file comparison in bash script

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -562,8 +562,8 @@ validate_remote_local_file_sizes()
     eval $invocation
 
     local downloaded_file="$1"
-    local remote_file_size="$2"
-
+    local remote_file_size=$(echo "$2" | awk '{ num = $1 + 0; print num }')
+    
     local file_size=''
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         file_size="$(stat -c '%s' "$downloaded_file")"
@@ -575,7 +575,7 @@ validate_remote_local_file_sizes()
         say "Downloaded file size is $file_size bytes."
 
         if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
-            if [ "$file_size" -ne "$(string_to_int "$remote_file_size")" ]; then
+            if [ "$file_size" -ne "$remote_file_size" ]; then
                 say "The remote and local file sizes are not equal. The remote file size is $remote_file_size bytes and the local size is $file_size bytes. The local package may be corrupted."
             else
                 say "The remote and local file sizes are equal."
@@ -585,11 +585,6 @@ validate_remote_local_file_sizes()
     else
         say "Either downloaded or local package size can not be measured. One of them may be corrupted."      
     fi 
-}
-
-# Function to convert a string to an integer
-function string_to_int {
-    echo "$1" | tr -d '\n' | sed 's/[^0-9]*//g'
 }
 
 # args:

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -563,7 +563,8 @@ validate_remote_local_file_sizes()
 
     local downloaded_file="$1"
     local remote_file_size="$2"
-    local file_size=0
+    local file_size=''
+
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         file_size="$(stat -c '%s' "$downloaded_file")"
     elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -575,8 +575,8 @@ validate_remote_local_file_sizes()
         say "Downloaded file size is $file_size bytes."
 
         if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
-            if [ "$file_size" != "$remote_file_size" ]; then
-                say "The remote and local file sizes are not equal. Remote file size is $remote_file_size bytes and local size is $file_size bytes. The local package may be corrupted."
+            if [ "$file_size" -ne "$(echo "$remote_file_size" | bc)" ]; then
+                say "The remote and local file sizes are not equal. The remote file size is $remote_file_size bytes and the local size is $file_size bytes. The local package may be corrupted."
             else
                 say "The remote and local file sizes are equal."
             fi

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -563,7 +563,7 @@ validate_remote_local_file_sizes()
 
     local downloaded_file="$1"
     local remote_file_size=$(echo "$2" | awk '{ num = $1 + 0; print num }')
-    
+
     local file_size=''
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         file_size="$(stat -c '%s' "$downloaded_file")"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -963,7 +963,7 @@ get_remote_file_size() {
     if machine_has "curl"; then
         file_size=$(curl -sI  "$zip_uri" | grep -i content-length | awk '{ num = $2 + 0; print num }')
     elif machine_has "wget"; then
-        file_size=$(wget --server-response -O /dev/null "$zip_uri" 2>&1 | grep -i '^Content-Length:' | awk '{ num = $2 + 0; print num }')
+        file_size=$(wget --spider --server-response -O /dev/null "$zip_uri" 2>&1 | grep -i 'Content-Length:' | awk '{ num = $2 + 0; print num }')
     else
         say "Neither curl nor wget is available on this system."
         return

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -562,9 +562,8 @@ validate_remote_local_file_sizes()
     eval $invocation
 
     local downloaded_file="$1"
-    local remote_file_size=$(echo "$2" | awk '{ num = $1 + 0; print num }')
-
-    local file_size=''
+    local remote_file_size="$2"
+    local file_size=0
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         file_size="$(stat -c '%s' "$downloaded_file")"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -575,7 +574,7 @@ validate_remote_local_file_sizes()
         say "Downloaded file size is $file_size bytes."
 
         if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
-            if [ "$file_size" -ne "$remote_file_size" ]; then
+            if [ "$remote_file_size" -ne "$file_size" ]; then
                 say "The remote and local file sizes are not equal. The remote file size is $remote_file_size bytes and the local size is $file_size bytes. The local package may be corrupted."
             else
                 say "The remote and local file sizes are equal."
@@ -961,9 +960,9 @@ get_remote_file_size() {
     local zip_uri="$1"
 
     if machine_has "curl"; then
-        file_size=$(curl -sI  "$zip_uri" | grep -i content-length | awk '{print $2}')
+        file_size=$(curl -sI  "$zip_uri" | grep -i content-length | awk '{ num = $2 + 0; print num }')
     elif machine_has "wget"; then
-        file_size=$(wget --server-response -O /dev/null "$zip_uri" 2>&1 | grep -i '^Content-Length:' | awk '{print $2}')
+        file_size=$(wget --server-response -O /dev/null "$zip_uri" 2>&1 | grep -i '^Content-Length:' | awk '{ num = $2 + 0; print num }')
     else
         say "Neither curl nor wget is available on this system."
         return
@@ -1497,7 +1496,7 @@ install_dotnet() {
     eval $invocation
     local download_failed=false
     local download_completed=false
-    local remote_file_size=''
+    local remote_file_size=0
 
     mkdir -p "$install_root"
     zip_path="${zip_path:-$(mktemp "$temporary_file_template")}"

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -575,7 +575,7 @@ validate_remote_local_file_sizes()
         say "Downloaded file size is $file_size bytes."
 
         if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
-            if [ "$file_size" -ne "$(echo "$remote_file_size" | bc)" ]; then
+            if [ "$file_size" -ne "$(string_to_int "$remote_file_size")" ]; then
                 say "The remote and local file sizes are not equal. The remote file size is $remote_file_size bytes and the local size is $file_size bytes. The local package may be corrupted."
             else
                 say "The remote and local file sizes are equal."
@@ -585,6 +585,11 @@ validate_remote_local_file_sizes()
     else
         say "Either downloaded or local package size can not be measured. One of them may be corrupted."      
     fi 
+}
+
+# Function to convert a string to an integer
+function string_to_int {
+    echo "$1" | tr -d '\n' | sed 's/[^0-9]*//g'
 }
 
 # args:


### PR DESCRIPTION
## Problem 

https://github.com/dotnet/install-scripts/issues/391

## Solution
`file_size` variable is an integer, and `remote_file_size` is a string. For the correct comparison, there is a need to cast `remote_file_size`to integer.