### PR TITLE
use stat from /usr/bin/stat explicitly

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -567,9 +567,9 @@ validate_remote_local_file_sizes()
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # hardcode in order to avoid conflicts with GNU stat
-        file_size="$(/usr/bin/stat -c '%s' "$downloaded_file")"
+        file_size="$(stat -c '%s' "$downloaded_file")"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
-        file_size="$(stat -f '%z' "$downloaded_file")"
+        file_size="$(/usr/bin/stat -f '%z' "$downloaded_file")"
     fi  
     
     if [ -n "$file_size" ]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -566,7 +566,8 @@ validate_remote_local_file_sizes()
     local file_size=''
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        file_size="$(stat -c '%s' "$downloaded_file")"
+        # hardcode in order to avoid conflicts with GNU stat
+        file_size="$(/usr/bin/stat -c '%s' "$downloaded_file")"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         file_size="$(stat -f '%z' "$downloaded_file")"
     fi  

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -566,9 +566,9 @@ validate_remote_local_file_sizes()
     local file_size=''
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # hardcode in order to avoid conflicts with GNU stat
         file_size="$(stat -c '%s' "$downloaded_file")"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # hardcode in order to avoid conflicts with GNU stat
         file_size="$(/usr/bin/stat -f '%z' "$downloaded_file")"
     fi  
     


### PR DESCRIPTION
## Fixes:
https://github.com/dotnet/install-scripts/issues/396

## Solution:
GNU stat can be specified in PATH before BSD one.
stat from /usr/bin/stat is needed for our purposes.