### PR TITLE
Tests updates after release dotnet 8

### DIFF
--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenMacosIsPassedToBash.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenMacosIsPassedToBash.verified.txt
@@ -1,3 +1,3 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.416/dotnet-sdk-6.0.416-osx-x64.tar.gz
-dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "6.0.416" --install-dir "dotnet-sdk" --architecture "x64" --os "osx"
+dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-osx-x64.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "8.0.100" --install-dir "dotnet-sdk" --architecture "x64" --os "osx"

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("6.0", "6\\.0\\..*", Quality.Daily),
                 ("6.0", "6\\.0\\..*", Quality.None),
                 ("STS", "7\\.0\\..*", Quality.None),
-                ("LTS", "6\\.0\\..*", Quality.None),
+                ("LTS", "8\\.0\\..*", Quality.None),
                 ("7.0", "7\\.0\\..*", Quality.None),
                 ("7.0", "7\\.0\\..*", Quality.Ga),
                 ("8.0", "8\\.0\\..*", Quality.None),

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("LTS", "6\\.0\\..*", Quality.None),
                 ("7.0", "7\\.0\\..*", Quality.None),
                 ("7.0", "7\\.0\\..*", Quality.Ga),
+                ("8.0", "8\\.0\\..*", Quality.None),
+                ("8.0", "8\\.0\\..*", Quality.Ga),
             };
 
         /// <summary>


### PR DESCRIPTION
## Problem
After recent LTS version upgrade current tests are failing. 

## Solution
The PR is updating current state of some tests which involves downloading LTS version of sdk or specific runtimes. 
It is also a prerequisite for the https://github.com/dotnet/install-scripts/pull/411 to complete. 

