### PR TITLE
Remove unused variable group from pipelines

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,7 +24,6 @@ variables:
       value: real
     - name: _UseBuildManifest
       value: False
-    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: DotNet-Install-Scripts-SDLValidation-Params

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,7 +22,6 @@ jobs:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2017
     variables:
-    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}


### PR DESCRIPTION
### Context
There is a variable group DotNet-Blob-Feed is referenced from the pipelines, and will be removed soon as part of this issue: https://github.com/dotnet/arcade/issues/13963. 
After upgrading to the dotnet 8 arcade there is no references left to this variable group its variables. 

### What is changing
Removing the variable group DotNet-Blob-Feed  from the pipeline 