### PR TITLE
Upgrade Microsoft.DotNet.Cli.Utils referenced packages

### DIFF
--- a/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
+++ b/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Build" Version="16.3.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.3.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Verify.Xunit" Version="19.10.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
+++ b/tests/Install-Scripts.Test/Install-Scripts.Test.csproj
@@ -33,8 +33,14 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.2.402" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.8.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.8.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="6.8.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.8.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.3.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.3.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Verify.Xunit" Version="19.10.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">


### PR DESCRIPTION
### Context
Currently referenced packages from Microsoft.DotNet.Cli.Utils are loaded implicitly during build process, hence the referenced packages versions differ from the required by the dependency and choosing the closest one. 
Example of process before: https://dev.azure.com/dnceng-public/public/_build/results?buildId=476794&view=logs&j=d6d0747d-862c-5953-c201-f4e1a93f2cef&t=f8f9cedb-7045-5b9b-3dc7-4063f90e4dfe 
Example of process for this PR: https://dev.azure.com/dnceng-public/public/_build/results?buildId=476832&view=logs&j=d6d0747d-862c-5953-c201-f4e1a93f2cef&t=f8f9cedb-7045-5b9b-3dc7-4063f90e4dfe

### Changes
Specify the exact version of the packages explicitly in the project file.

