### PR TITLE
Detect ARMhf userland on top of AARCH64 kernel

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -303,6 +303,11 @@ get_machine_architecture() {
             return 0
             ;;
         aarch64|arm64)
+            if [ "$(getconf LONG_BIT)" -lt 64 ]; then
+                # This is 32-bit OS running on 64-bit CPU (for example Raspberry Pi OS)
+                echo "arm"
+                return 0
+            fi
             echo "arm64"
             return 0
             ;;


### PR DESCRIPTION
Raspberry Pi 4/5 supports running 32-bit user land with a 64-bit Linux kernel. Detect that and install linux-arm version of .NET instead of linux-arm64. The arm64 version doesn't work in that scenario.