### PR TITLE
Update install-dotnet-preview.sh to support install of 9.0.0-preview

### DIFF
--- a/src/install-dotnet-preview.sh
+++ b/src/install-dotnet-preview.sh
@@ -2,7 +2,7 @@
 
 # System must first have curl installed.
 # The following command will download the installation script and run it.
-# curl -L https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/install-dotnet-preview.sh -o install-dotnet-preview.sh && bash install-dotnet-preview.sh
+# curl -L https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/install-dotnet-preview.sh -o install-dotnet-preview.sh && bash install-dotnet-preview.sh
 # The script will
 #   - install any additional dependences needed for the script to continue
 #   - download a tar.gz containing the .NET preview installer packages to the current directory
@@ -29,8 +29,8 @@ DOWNLOAD_DIR=$PWD
 DOTNET_PACKAGE_DIR="dotnet_packages"
 SUPPORTED_DISTRO=1
 
-DEPS_BUILD="23479.6"
-PREVIEW_NUMBER="2"
+DEPS_BUILD="24080.9"
+PREVIEW_NUMBER="1"
 
 declare -a ADDITIONAL_DEPS
 
@@ -75,27 +75,27 @@ function distro_check()
           ;;
         *"Fedora"* | *"Red Hat"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/dotnet-runtime-deps-8.0.0-rc.$PREVIEW_NUMBER.$DEPS_BUILD-fedora.34-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-fedora.34-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "compat-openssl10" "libicu")
           ;;
         *"openSUSE"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/dotnet-runtime-deps-8.0.0-rc.$PREVIEW_NUMBER.$DEPS_BUILD-opensuse.42-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-opensuse.42-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libopenssl1_0_0" "libicu")
           ;;
         *"sles"**)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/dotnet-runtime-deps-8.0.0-rc.$PREVIEW_NUMBER.$DEPS_BUILD-sles.12-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-sles.12-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libopenssl1_0_0" "libicu")
           ;;
         *"Oracle"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/dotnet-runtime-deps-8.0.0-rc.$PREVIEW_NUMBER.$DEPS_BUILD-oraclelinux.8-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-oraclelinux.8-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libicu")
           ;;
         *"CentOS"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/dotnet-runtime-deps-8.0.0-rc.$PREVIEW_NUMBER.$DEPS_BUILD-centos.7-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-centos.7-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libicu")
           ;;
         *) SUPPORTED_DISTRO=0 ;;
@@ -107,20 +107,20 @@ function download_preview()
     case $PACKAGE_TYPE in
         "rpm")
             echo "*** Setting package type to rpm."
-            DOTNET_SRC="dotnet-8.0.0-rc.$PREVIEW_NUMBER-rpm.tar.gz"
+            DOTNET_SRC="dotnet-9.0.0-preview.$PREVIEW_NUMBER-rpm.tar.gz"
             ;;
         "deb")
             echo "*** Setting package type to deb."
-            DOTNET_SRC="dotnet-8.0.0-rc.$PREVIEW_NUMBER-deb.tar.gz"
+            DOTNET_SRC="dotnet-9.0.0-preview.$PREVIEW_NUMBER-deb.tar.gz"
             ;;
         *)
     esac
 
     echo "*** Download source: ${DOTNET_SRC}"
     echo
-    echo "*** Downloading https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/$DOTNET_SRC to $DOWNLOAD_DIR ..."
+    echo "*** Downloading https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/$DOTNET_SRC to $DOWNLOAD_DIR ..."
 
-    curl "https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/8.0.0-rc.$PREVIEW_NUMBER/"$DOTNET_SRC -o $DOWNLOAD_DIR/$DOTNET_SRC
+    curl "https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/"$DOTNET_SRC -o $DOWNLOAD_DIR/$DOTNET_SRC
     
     echo
     echo "*** Unpacking ${DOTNET_SRC} ..."
@@ -183,7 +183,7 @@ function install()
         rpm -ivh --replacepkgs $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
     elif [ $PACKAGE_TYPE == "deb" ]
     then
-        apt install -y $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
+        apt install -y --allow-downgrades $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
     fi
 }
 
@@ -201,5 +201,5 @@ then
     echo
     install
 else
-    echo "${DISTRO_NAME} is not supported by the .NET 5 Preview installer."
+    echo "${DISTRO_NAME} is not supported by the .NET 9 Preview installer."
 fi


### PR DESCRIPTION
The current script is linked in https://github.com/dotnet/core/blob/main/release-notes/9.0/install-linux.md but does not support the installation of 9.0.0-preview. This update the links to install the current .net 9 preview.