### PR TITLE
Correct broken redirects in the case that the response ends without final code 2xx/4xx/5xx

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1271,6 +1271,12 @@ get_download_link_from_aka_ms() {
     http_codes=$( echo "$response" | awk '$1 ~ /^HTTP/ {print $2}' )
     # They all need to be 301, otherwise some links are broken (except for the last, which is not a redirect but 200 or 404).
     broken_redirects=$( echo "$http_codes" | sed '$d' | grep -v '301' )
+    # The response may end without final code 2xx/4xx/5xx somehow, e.g. network restrictions on www.bing.com causes redirecting to bing.com fails with connection refused.
+    # In this case it should not exclude the last.
+    last_http_code=$(  echo "$http_codes" | tail -n 1 )
+    if ! [[ $last_http_code =~ ^(2|4|5)[0-9][0-9]$ ]]; then
+        broken_redirects=$( echo "$http_codes" | grep -v '301' )
+    fi
 
     # All HTTP codes are 301 (Moved Permanently), the redirect link exists.
     if [[ -z "$broken_redirects" ]]; then

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [InlineData("6.0", "daily", @"https://aka.ms/dotnet/6.0/daily/dotnet-sdk-")]
         [InlineData("7.0", "daily", @"https://aka.ms/dotnet/7.0/daily/dotnet-sdk-")]
+        [InlineData("9.0", "preview", @"https://aka.ms/dotnet/9.0/preview/dotnet-sdk-")]
         public void SDK_IntegrationTest(string channel, string quality, string expectedLink)
         {
             string expectedLinkPattern = Regex.Escape(expectedLink);

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -38,6 +38,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("7.0", "7\\.0\\..*", Quality.Ga),
                 ("8.0", "8\\.0\\..*", Quality.None),
                 ("8.0", "8\\.0\\..*", Quality.Ga),
+                ("9.0", "9\\.0\\..*", Quality.None),
+                ("9.0", "9\\.0\\..*", Quality.Preview),
+                ("9.0", "9\\.0\\..*", Quality.Ga),
             };
 
         /// <summary>


### PR DESCRIPTION
### Fix
#461

### Solution
In the case that the response ends without final code 2xx/4xx/5xx, getting broken redirects includes last http code.