### PR TITLE
Update linux pool to 1es-ubuntu-2204

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -95,7 +95,7 @@ extends:
         timeoutInMinutes: 30
         pool:
           name: netcore1espool-internal
-          image: 1es-ubuntu-2204-pt
+          image: 1es-ubuntu-2204
           os: linux
         steps:
         - checkout: self


### PR DESCRIPTION
The internal branch fails with "Exception Image 1es-ubuntu-2204-pt doesn't exist in pool NetCore1ESPool-Internal"
This PR addresses it. 