### PR TITLE
Update the build status id in the links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/dotnet.install-scripts?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=846&branchName=main)
+[![Build Status](https://dev.azure.com/dnceng-public/public/_apis/build/status/73?branchName=main&label=Public)](https://dev.azure.com/dnceng-public/public/_build?definitionId=73)
 
 This repo is the central place for dotnet install and install dotnet preview scripts.
 


### PR DESCRIPTION
The build status links and actual status is not up to date. 
Updated the link to properly point to the public builds

Example: https://github.com/f-alizada/install-scripts/tree/dev/f-alizada/update-build-status?tab=readme-ov-file