### PR TITLE
detect IBM Power architecture

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -331,6 +331,10 @@ get_machine_architecture() {
             echo "riscv64"
             return 0
             ;;
+        powerpc|ppc)
+            echo "ppc"
+            return 0
+            ;;
         esac
     fi
 


### PR DESCRIPTION
IBM Power architecture is not correctly detected on FreeBSD 15.0-CURRENT

this patch is one step towards the bringup on this arch

but the script fails because Microsoft don't provide any pre-built PPC dotnet sdk (another issue)