### PR TITLE
Remove MaestroApiAccessToken usage

### DIFF
--- a/eng/common/templates-official/post-build/common-variables.yml
+++ b/eng/common/templates-official/post-build/common-variables.yml
@@ -8,8 +8,6 @@ variables:
   # Default Maestro++ API Endpoint and API Version
   - name: MaestroApiEndPoint
     value: "https://maestro-prod.westus2.cloudapp.azure.com"
-  - name: MaestroApiAccessToken
-    value: $(MaestroAccessToken)
   - name: MaestroApiVersion
     value: "2020-02-20"
 

--- a/eng/common/templates-official/post-build/trigger-subscription.yml
+++ b/eng/common/templates-official/post-build/trigger-subscription.yml
@@ -2,12 +2,14 @@ parameters:
   ChannelId: 0
 
 steps:
-- task: PowerShell@2
+- task: AzureCLI@2
   displayName: Triggering subscriptions
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
+    azureSubscription: "Darc: Maestro Production"
+    scriptType: ps
+    scriptLocation: scriptPath
+    scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
     arguments: -SourceRepo $(Build.Repository.Uri)
       -ChannelId ${{ parameters.ChannelId }}
-      -MaestroApiAccessToken $(MaestroAccessToken)
       -MaestroApiEndPoint $(MaestroApiEndPoint)
       -MaestroApiVersion $(MaestroApiVersion)

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -8,8 +8,6 @@ variables:
   # Default Maestro++ API Endpoint and API Version
   - name: MaestroApiEndPoint
     value: "https://maestro.dot.net"
-  - name: MaestroApiAccessToken
-    value: $(MaestroAccessToken)
   - name: MaestroApiVersion
     value: "2020-02-20"
 

--- a/eng/common/templates/post-build/trigger-subscription.yml
+++ b/eng/common/templates/post-build/trigger-subscription.yml
@@ -2,12 +2,14 @@ parameters:
   ChannelId: 0
 
 steps:
-- task: PowerShell@2
+- task: AzureCLI@2
   displayName: Triggering subscriptions
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
+    azureSubscription: "Darc: Maestro Production"
+    scriptType: ps
+    scriptLocation: scriptPath
+    scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
     arguments: -SourceRepo $(Build.Repository.Uri)
       -ChannelId ${{ parameters.ChannelId }}
-      -MaestroApiAccessToken $(MaestroAccessToken)
       -MaestroApiEndPoint $(MaestroApiEndPoint)
       -MaestroApiVersion $(MaestroApiVersion)

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -30,11 +30,16 @@ jobs:
     - checkout: self
       clean: true
     steps:
-    - script: eng\update-packagesource.cmd 
-        -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT)
-        -barToken $(MaestroAccessToken)
-        -packagesSource $(Build.SourcesDirectory)/build_stage_artifacts
+    - task: AzureCLI@2
       displayName: Update package source
+      inputs:
+        azureSubscription: "Darc: Maestro Production"
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: >
+          .\eng\update-packagesource.ps1
+          -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT)
+          -packagesSource $(Build.SourcesDirectory)/build_stage_artifacts
     - script: eng\common\cibuild.cmd
         $(_BuildArgs)
         /p:DotNetPublishBlobFeedUrl=$(_ValidateBlobFeedUrl)


### PR DESCRIPTION
## Fixes #502

## Context
Removed $(MaestroAccessToken) , since this token is getting deprecated in favor of using a secretless auth via a service connection.

Tested on internal build: 
https://dnceng.visualstudio.com/internal/_build/results?buildId=2510579&view=results