### PR TITLE
Fix net10.0 detection for osx-arm64

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -423,14 +423,16 @@ get_normalized_architecture_for_specific_sdk_version() {
 # args:
 # version or channel - $1
 is_arm64_supported() {
-    #any channel or version that starts with the specified versions
-    case "$1" in
-        ( "1"* | "2"* | "3"*  | "4"* | "5"*) 
-            echo false
-            return 0
-    esac
+    # Extract the major version by splitting on the dot
+    major_version="${1%%.*}"
 
-    echo true
+    # Check if the major version is a valid number and less than 6
+    if [[ "$major_version" -lt 6 ]]; then
+        echo false
+    else
+        echo true
+    fi
+
     return 0
 }
 

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -427,12 +427,16 @@ is_arm64_supported() {
     major_version="${1%%.*}"
 
     # Check if the major version is a valid number and less than 6
-    if [[ "$major_version" -lt 6 ]]; then
-        echo false
-    else
-        echo true
-    fi
+    case "$major_version" in
+        [0-9]*)  
+            if [ "$major_version" -lt 6 ]; then
+                echo false
+                return 0
+            fi
+            ;;
+    esac
 
+    echo true
     return 0
 }
 


### PR DESCRIPTION
It was downloading osx-x64 on osx-arm64 machine due to relaxed pattern matching:

```sh
$ ./dotnet-install.sh --quality daily --channel "10.0" --install-dir ~/.dotnet10 -verbose
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Calling: machine_has curl
dotnet-install: Calling: calculate_vars 
dotnet-install: Calling: get_normalized_architecture_from_architecture <auto>
dotnet-install: Calling: get_machine_architecture 
dotnet-install: Normalized architecture: 'arm64'.
dotnet-install: Calling: get_normalized_os 
dotnet-install: Calling: get_current_os_name 
dotnet-install: Normalized OS: 'osx'.
dotnet-install: Calling: get_normalized_quality daily
dotnet-install: Normalized quality: 'daily'.
dotnet-install: Calling: get_normalized_channel 10.0
dotnet-install: Normalized channel: '10.0'.
dotnet-install: Calling: get_normalized_product 
dotnet-install: Normalized product: 'dotnet-sdk'.
dotnet-install: Calling: resolve_installation_path /Users/adeel/.dotnet10
dotnet-install: InstallRoot: '/Users/adeel/.dotnet10'.
dotnet-install: Calling: get_normalized_architecture_for_specific_sdk_version Latest 10.0 arm64
dotnet-install: Calling: get_current_os_name 
dotnet-install: Changing user architecture from 'arm64' to 'x64' because .NET SDKs prior to version 6.0 do not support arm64.
...
```

This delta fixes the issue by parsing major version from the input and comparing if it is less than 6.