### PR TITLE
sync install-dotnet-preview.sh from blob storage

### DIFF
--- a/src/install-dotnet-preview.sh
+++ b/src/install-dotnet-preview.sh
@@ -2,7 +2,7 @@
 
 # System must first have curl installed.
 # The following command will download the installation script and run it.
-# curl -L https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/install-dotnet-preview.sh -o install-dotnet-preview.sh && bash install-dotnet-preview.sh
+# curl -L https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/install-dotnet-$PRERELEASETYPE.sh -o install-dotnet-$PRERELEASETYPE.sh && bash install-dotnet-$PRERELEASETYPE.sh
 # The script will
 #   - install any additional dependences needed for the script to continue
 #   - download a tar.gz containing the .NET preview installer packages to the current directory
@@ -29,8 +29,9 @@ DOWNLOAD_DIR=$PWD
 DOTNET_PACKAGE_DIR="dotnet_packages"
 SUPPORTED_DISTRO=1
 
-DEPS_BUILD="24080.9"
-PREVIEW_NUMBER="1"
+DEPS_BUILD="24473.5"
+PREVIEW_NUMBER="2"
+PRERELEASETYPE="rc" # rc, preview
 
 declare -a ADDITIONAL_DEPS
 
@@ -41,15 +42,7 @@ function distro_check()
           PACKAGE_TYPE="deb"
           ADDITIONAL_DEPS=("tar" "gzip" "curl")
           ;;
-        *"Ubuntu 16.04"* | *"Mint 18"*)
-          PACKAGE_TYPE="deb"
-          ADDITIONAL_DEPS=("tar" "gzip" "curl")
-          ;;
         *"Ubuntu 18.04"* | *"Mint 19"*)
-          PACKAGE_TYPE="deb"
-          ADDITIONAL_DEPS=("tar" "gzip" "curl")
-          ;;
-        *"Ubuntu 19.10"*)
           PACKAGE_TYPE="deb"
           ADDITIONAL_DEPS=("tar" "gzip" "curl")
           ;;
@@ -57,15 +50,7 @@ function distro_check()
           PACKAGE_TYPE="deb"
           ADDITIONAL_DEPS=("tar" "gzip" "curl")
           ;;
-        *"Ubuntu 20.10"* | *"Groovy"*)
-          PACKAGE_TYPE="deb"
-          ADDITIONAL_DEPS=("tar" "gzip" "curl")
-          ;;
         *"Ubuntu 22.04"* | *"Jammy"*)
-          PACKAGE_TYPE="deb"
-          ADDITIONAL_DEPS=("tar" "gzip" "curl")
-          ;;
-        *"Ubuntu 22.10"* | *"Kinetic"*)
           PACKAGE_TYPE="deb"
           ADDITIONAL_DEPS=("tar" "gzip" "curl")
           ;;
@@ -73,29 +58,33 @@ function distro_check()
           PACKAGE_TYPE="deb"
           ADDITIONAL_DEPS=("tar" "gzip" "curl")
           ;;
+        *"Ubuntu 23.10"* | *"Mantic"*)
+          PACKAGE_TYPE="deb"
+          ADDITIONAL_DEPS=("tar" "gzip" "curl")
+          ;;
         *"Fedora"* | *"Red Hat"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-fedora.34-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER.$DEPS_BUILD-fedora.34-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "compat-openssl10" "libicu")
           ;;
         *"openSUSE"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-opensuse.42-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER.$DEPS_BUILD-opensuse.42-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libopenssl1_0_0" "libicu")
           ;;
         *"sles"**)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-sles.12-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER.$DEPS_BUILD-sles.12-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libopenssl1_0_0" "libicu")
           ;;
         *"Oracle"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-oraclelinux.8-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER.$DEPS_BUILD-oraclelinux.8-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libicu")
           ;;
         *"CentOS"*)
           PACKAGE_TYPE="rpm"
-          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-preview.$PREVIEW_NUMBER.$DEPS_BUILD-centos.7-x64.rpm"
+          DEPS_PACKAGE="https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/dotnet-runtime-deps-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER.$DEPS_BUILD-centos.8-x64.rpm"
           ADDITIONAL_DEPS=("tar" "gzip" "libicu")
           ;;
         *) SUPPORTED_DISTRO=0 ;;
@@ -107,20 +96,20 @@ function download_preview()
     case $PACKAGE_TYPE in
         "rpm")
             echo "*** Setting package type to rpm."
-            DOTNET_SRC="dotnet-9.0.0-preview.$PREVIEW_NUMBER-rpm.tar.gz"
+            DOTNET_SRC="dotnet-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER-rpm.tar.gz"
             ;;
         "deb")
             echo "*** Setting package type to deb."
-            DOTNET_SRC="dotnet-9.0.0-preview.$PREVIEW_NUMBER-deb.tar.gz"
+            DOTNET_SRC="dotnet-9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER-deb.tar.gz"
             ;;
         *)
     esac
 
     echo "*** Download source: ${DOTNET_SRC}"
     echo
-    echo "*** Downloading https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/$DOTNET_SRC to $DOWNLOAD_DIR ..."
+    echo "*** Downloading https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/$DOTNET_SRC to $DOWNLOAD_DIR ..."
 
-    curl "https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-preview.$PREVIEW_NUMBER/"$DOTNET_SRC -o $DOWNLOAD_DIR/$DOTNET_SRC
+    curl "https://dotnetcli.blob.core.windows.net/dotnet/release/install-preview/9.0.0-$PRERELEASETYPE.$PREVIEW_NUMBER/"$DOTNET_SRC -o $DOWNLOAD_DIR/$DOTNET_SRC
     
     echo
     echo "*** Unpacking ${DOTNET_SRC} ..."
@@ -201,5 +190,5 @@ then
     echo
     install
 else
-    echo "${DISTRO_NAME} is not supported by the .NET 9 Preview installer."
+    echo "${DISTRO_NAME} is not supported by the .NET 9 Preview installer. Please use the dotnet-install script - https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script."
 fi


### PR DESCRIPTION
the script is outdated, we don't want to install previews but RCs now