### PR TITLE
Implement fallback detection of redirects for the new CDNs

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1136,9 +1136,11 @@ function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $Normal
 
 function Get-Feeds-To-Use() {
     $feeds = @(
-        "https://builds.dotnet.microsoft.com/dotnet"
+        "https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet" # direct-access alias for builds.dotnet.microsoft.com until certs are ready for that alias
+        #"https://builds.dotnet.microsoft.com/dotnet"
         "https://dotnetcli.azureedge.net/dotnet"
-        "https://ci.dot.net/public"
+        "https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public" # direct-access alias for ci.dot.net until certs are ready for that alias
+        #"https://ci.dot.net/public"
         "https://dotnetbuilds.azureedge.net/public"
     )
 

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -111,35 +111,35 @@
 #>
 [cmdletbinding()]
 param(
-   [string]$Channel="LTS",
-   [string]$Quality,
-   [string]$Version="Latest",
-   [switch]$Internal,
-   [string]$JSonFile,
-   [Alias('i')][string]$InstallDir="<auto>",
-   [string]$Architecture="<auto>",
-   [string]$Runtime,
-   [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
-   [switch]$SharedRuntime,
-   [switch]$DryRun,
-   [switch]$NoPath,
-   [string]$AzureFeed,
-   [string]$UncachedFeed,
-   [string]$FeedCredential,
-   [string]$ProxyAddress,
-   [switch]$ProxyUseDefaultCredentials,
-   [string[]]$ProxyBypassList=@(),
-   [switch]$SkipNonVersionedFiles,
-   [switch]$NoCdn,
-   [int]$DownloadTimeout=1200,
-   [switch]$KeepZip,
-   [string]$ZipPath=[System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
-   [switch]$Help
+    [string]$Channel = "LTS",
+    [string]$Quality,
+    [string]$Version = "Latest",
+    [switch]$Internal,
+    [string]$JSonFile,
+    [Alias('i')][string]$InstallDir = "<auto>",
+    [string]$Architecture = "<auto>",
+    [string]$Runtime,
+    [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
+    [switch]$SharedRuntime,
+    [switch]$DryRun,
+    [switch]$NoPath,
+    [string]$AzureFeed,
+    [string]$UncachedFeed,
+    [string]$FeedCredential,
+    [string]$ProxyAddress,
+    [switch]$ProxyUseDefaultCredentials,
+    [string[]]$ProxyBypassList = @(),
+    [switch]$SkipNonVersionedFiles,
+    [switch]$NoCdn,
+    [int]$DownloadTimeout = 1200,
+    [switch]$KeepZip,
+    [string]$ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
+    [switch]$Help
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference="Stop"
-$ProgressPreference="SilentlyContinue"
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 function Say($str) {
     try {
@@ -243,14 +243,13 @@ function Get-Machine-Architecture() {
     # To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
     # PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
     # Possible values: amd64, x64, x86, arm64, arm
-    if( $ENV:PROCESSOR_ARCHITEW6432 -ne $null ) {
+    if ( $ENV:PROCESSOR_ARCHITEW6432 -ne $null ) {
         return $ENV:PROCESSOR_ARCHITEW6432
     }
 
     try {        
-        if( ((Get-CimInstance -ClassName CIM_OperatingSystem).OSArchitecture) -like "ARM*") {
-            if( [Environment]::Is64BitOperatingSystem )
-            {
+        if ( ((Get-CimInstance -ClassName CIM_OperatingSystem).OSArchitecture) -like "ARM*") {
+            if ( [Environment]::Is64BitOperatingSystem ) {
                 return "arm64"
             }  
             return "arm"
@@ -279,13 +278,13 @@ function Get-CLIArchitecture-From-Architecture([string]$Architecture) {
     }
 }
 
-function ValidateFeedCredential([string] $FeedCredential)
-{
+function ValidateFeedCredential([string] $FeedCredential) {
     if ($Internal -and [string]::IsNullOrWhitespace($FeedCredential)) {
         $message = "Provide credentials via -FeedCredential parameter."
         if ($DryRun) {
             Say-Warning "$message"
-        } else {
+        }
+        else {
             throw "$message"
         }
     }
@@ -362,7 +361,7 @@ function Get-Version-From-LatestVersion-File-Content([string]$VersionText) {
 
     $VersionInfo = @{
         CommitHash = $(if ($Data.Count -gt 1) { $Data[0] })
-        Version = $Data[-1] # last line is always the version number.
+        Version    = $Data[-1] # last line is always the version number.
     }
     return $VersionInfo
 }
@@ -377,8 +376,7 @@ function Load-Assembly([string] $Assembly) {
     }
 }
 
-function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, [bool]$DisableFeedCredential)
-{
+function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, [bool]$DisableFeedCredential) {
     $cts = New-Object System.Threading.CancellationTokenSource
 
     $downloadScript = {
@@ -389,19 +387,21 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
             # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
             Load-Assembly -Assembly System.Net.Http
 
-            if(-not $ProxyAddress) {
+            if (-not $ProxyAddress) {
                 try {
                     # Despite no proxy being explicitly specified, we may still be behind a default proxy
                     $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
-                    if($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
+                    if ($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
                         if ($null -ne $DefaultProxy.GetProxy($Uri)) {
                             $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
-                        } else {
+                        }
+                        else {
                             $ProxyAddress = $null
                         }
                         $ProxyUseDefaultCredentials = $true
                     }
-                } catch {
+                }
+                catch {
                     # Eat the exception and move forward as the above code is an attempt
                     #    at resolving the DefaultProxy that may not have been a problem.
                     $ProxyAddress = $null
@@ -410,15 +410,14 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
             }
 
             $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
-            if($ProxyAddress) {
-                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{
-                    Address=$ProxyAddress;
-                    UseDefaultCredentials=$ProxyUseDefaultCredentials;
-                    BypassList = $ProxyBypassList;
+            if ($ProxyAddress) {
+                $HttpClientHandler.Proxy = New-Object System.Net.WebProxy -Property @{
+                    Address               = $ProxyAddress;
+                    UseDefaultCredentials = $ProxyUseDefaultCredentials;
+                    BypassList            = $ProxyBypassList;
                 }
             }       
-            if ($DisableRedirect)
-            {
+            if ($DisableRedirect) {
                 $HttpClientHandler.AllowAutoRedirect = $false
             }
             $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
@@ -427,7 +426,7 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
             # Defaulting to 20 minutes allows it to work over much slower connections.
             $HttpClient.Timeout = New-TimeSpan -Seconds $DownloadTimeout
 
-            if ($HeaderOnly){
+            if ($HeaderOnly) {
                 $completionOption = [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
             }
             else {
@@ -452,8 +451,7 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
                     $DownloadException.Data["StatusCode"] = [int] $Response.StatusCode
                     $DownloadException.Data["ErrorMessage"] = "Unable to download $Uri. Returned HTTP status code: " + $DownloadException.Data["StatusCode"]
 
-                    if (404 -eq [int] $Response.StatusCode)
-                    {
+                    if (404 -eq [int] $Response.StatusCode) {
                         $cts.Cancel()
                     }
                 }
@@ -470,8 +468,8 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
             $CurrentException = $PSItem.Exception
             $ErrorMsg = $CurrentException.Message + "`r`n"
             while ($CurrentException.InnerException) {
-              $CurrentException = $CurrentException.InnerException
-              $ErrorMsg += $CurrentException.Message + "`r`n"
+                $CurrentException = $CurrentException.InnerException
+                $ErrorMsg += $CurrentException.Message + "`r`n"
             }
 
             # Check if there is an issue concerning TLS.
@@ -483,7 +481,7 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
             throw $DownloadException
         }
         finally {
-             if ($null -ne $HttpClient) {
+            if ($null -ne $HttpClient) {
                 $HttpClient.Dispose()
             }
         }
@@ -492,10 +490,8 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
     try {
         return Invoke-With-Retry $downloadScript $cts.Token
     }
-    finally
-    {
-        if ($null -ne $cts)
-        {
+    finally {
+        if ($null -ne $cts) {
             $cts.Dispose()
         }
     }
@@ -613,11 +609,9 @@ function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string
     elseif ($Runtime -eq "windowsdesktop") {
         # The windows desktop runtime is part of the core runtime layout prior to 5.0
         $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
-        if ($SpecificVersion -match '^(\d+)\.(.*)$')
-        {
+        if ($SpecificVersion -match '^(\d+)\.(.*)$') {
             $majorVersion = [int]$Matches[1]
-            if ($majorVersion -ge 5)
-            {
+            if ($majorVersion -ge 5) {
                 $PayloadURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
             }
         }
@@ -667,8 +661,7 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [stri
 
             if ($productVersionResponse.StatusCode -eq 200) {
                 $productVersion = $productVersionResponse.Content.ReadAsStringAsync().Result.Trim()
-                if ($productVersion -ne $SpecificVersion)
-                {
+                if ($productVersion -ne $SpecificVersion) {
                     Say "Using alternate version $productVersion found in $ProductVersionTxtURL"
                 }
                 return $productVersion
@@ -683,8 +676,7 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [stri
     }
 
     # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
-    if ([string]::IsNullOrEmpty($PackageDownloadLink))
-    {
+    if ([string]::IsNullOrEmpty($PackageDownloadLink)) {
         Say-Verbose "Using the default value '$SpecificVersion' as the product version."
         return $SpecificVersion
     }
@@ -696,21 +688,21 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [stri
 function Get-Product-Version-Url([string]$AzureFeed, [string]$SpecificVersion, [string]$PackageDownloadLink, [bool]$Flattened) {
     Say-Invocation $MyInvocation
 
-    $majorVersion=$null
+    $majorVersion = $null
     if ($SpecificVersion -match '^(\d+)\.(.*)') {
-        $majorVersion = $Matches[1] -as[int]
+        $majorVersion = $Matches[1] -as [int]
     }
 
-    $pvFileName='productVersion.txt'
-    if($Flattened) {
-        if(-not $Runtime) {
-            $pvFileName='sdk-productVersion.txt'
+    $pvFileName = 'productVersion.txt'
+    if ($Flattened) {
+        if (-not $Runtime) {
+            $pvFileName = 'sdk-productVersion.txt'
         }
-        elseif($Runtime -eq "dotnet") {
-            $pvFileName='runtime-productVersion.txt'
+        elseif ($Runtime -eq "dotnet") {
+            $pvFileName = 'runtime-productVersion.txt'
         }
         else {
-            $pvFileName="$Runtime-productVersion.txt"
+            $pvFileName = "$Runtime-productVersion.txt"
         }
     }
 
@@ -736,7 +728,7 @@ function Get-Product-Version-Url([string]$AzureFeed, [string]$SpecificVersion, [
         }
     }
     else {
-        $ProductVersionTxtURL = $PackageDownloadLink.Substring(0, $PackageDownloadLink.LastIndexOf("/"))  + "/$pvFileName"
+        $ProductVersionTxtURL = $PackageDownloadLink.Substring(0, $PackageDownloadLink.LastIndexOf("/")) + "/$pvFileName"
     }
 
     Say-Verbose "Constructed productVersion link: $ProductVersionTxtURL"
@@ -744,16 +736,14 @@ function Get-Product-Version-Url([string]$AzureFeed, [string]$SpecificVersion, [
     return $ProductVersionTxtURL
 }
 
-function Get-ProductVersionFromDownloadLink([string]$PackageDownloadLink, [string]$SpecificVersion)
-{
+function Get-ProductVersionFromDownloadLink([string]$PackageDownloadLink, [string]$SpecificVersion) {
     Say-Invocation $MyInvocation
 
     #product specific version follows the product name
     #for filename 'dotnet-sdk-3.1.404-win-x64.zip': the product version is 3.1.400
     $filename = $PackageDownloadLink.Substring($PackageDownloadLink.LastIndexOf("/") + 1)
     $filenameParts = $filename.Split('-')
-    if ($filenameParts.Length -gt 2)
-    {
+    if ($filenameParts.Length -gt 2) {
         $productVersion = $filenameParts[2]
         Say-Verbose "Extracted product version '$productVersion' from download link '$PackageDownloadLink'."
     }
@@ -788,12 +778,13 @@ function Resolve-Installation-Path([string]$InstallDir) {
 
 function Test-User-Write-Access([string]$InstallDir) {
     try {
-        $tempFileName=[guid]::NewGuid().ToString()
-        $tempFilePath=Join-Path -Path $InstallDir -ChildPath $tempFileName
+        $tempFileName = [guid]::NewGuid().ToString()
+        $tempFilePath = Join-Path -Path $InstallDir -ChildPath $tempFileName
         New-Item -Path $tempFilePath -ItemType File -Force
         Remove-Item $tempFilePath -Force
         return $true
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -873,7 +864,7 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
             if (($null -eq $PathWithVersion) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
                 $DestinationPath = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $entry.FullName)
                 $DestinationDir = Split-Path -Parent $DestinationPath
-                $OverrideFiles=$OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
+                $OverrideFiles = $OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
                 if ((-Not $DestinationPath.EndsWith("\")) -And $OverrideFiles) {
                     New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
                     [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $DestinationPath, $OverrideNonVersionedFiles)
@@ -881,8 +872,7 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
             }
         }
     }
-    catch
-    {
+    catch {
         Say-Error "Failed to extract package. Exception: $_"
         throw;
     }
@@ -969,7 +959,8 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot) {
         if (-Not $env:path.Contains($SuffixedBinPath)) {
             Say "Adding to current process PATH: `"$BinPath`". Note: This change will not be visible if PowerShell was run as a child process."
             $env:path = $SuffixedBinPath + $env:path
-        } else {
+        }
+        else {
             Say-Verbose "Current process PATH already contains `"$BinPath`""
         }
     }
@@ -978,33 +969,57 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot) {
     }
 }
 
-function PrintDryRunOutput($Invocation, $DownloadLinks)
-{
+function PrintDryRunOutput($Invocation, $DownloadLinks) {
     Say "Payload URLs:"
     
-    for ($linkIndex=0; $linkIndex -lt $DownloadLinks.count; $linkIndex++) {
+    for ($linkIndex = 0; $linkIndex -lt $DownloadLinks.count; $linkIndex++) {
         Say "URL #$linkIndex - $($DownloadLinks[$linkIndex].type): $($DownloadLinks[$linkIndex].downloadLink)"
     }
     $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
     if ($Runtime -eq "dotnet") {
-       $RepeatableCommand+=" -Runtime `"dotnet`""
+        $RepeatableCommand += " -Runtime `"dotnet`""
     }
     elseif ($Runtime -eq "aspnetcore") {
-       $RepeatableCommand+=" -Runtime `"aspnetcore`""
+        $RepeatableCommand += " -Runtime `"aspnetcore`""
     }
 
     foreach ($key in $Invocation.BoundParameters.Keys) {
-        if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version","Quality","FeedCredential") -contains $key)) {
-            $RepeatableCommand+=" -$key `"$($Invocation.BoundParameters[$key])`""
+        if (-not (@("Architecture", "Channel", "DryRun", "InstallDir", "Runtime", "SharedRuntime", "Version", "Quality", "FeedCredential") -contains $key)) {
+            $RepeatableCommand += " -$key `"$($Invocation.BoundParameters[$key])`""
         }
     }
     if ($Invocation.BoundParameters.Keys -contains "FeedCredential") {
-        $RepeatableCommand+=" -FeedCredential `"<feedCredential>`""
+        $RepeatableCommand += " -FeedCredential `"<feedCredential>`""
     }
     Say "Repeatable invocation: $RepeatableCommand"
-    if ($SpecificVersion -ne $EffectiveVersion)
-    {
+    if ($SpecificVersion -ne $EffectiveVersion) {
         Say "NOTE: Due to finding a version manifest with this runtime, it would actually install with version '$EffectiveVersion'"
+    }
+}
+
+# grab the 'stem' of the redirect and check it against all of our configured feeds, 
+# if it matches, we can be sure that the redirect is valid and we should use it for
+# subsequent processing
+function Sanitize-RedirectUrl([string]$url) {
+    $urlSegments = ([System.Uri]$url).Segments;
+    $urlStem = $urlSegments[2..($urlSegments.Length - 1)] -join "";
+    Write-Verbose "Checking configured feeds for the asset at $urlStem"
+    foreach ($prospectiveFeed in $feeds) {
+        $trialUrl = "$prospectiveFeed/$urlStem";
+        Write-Verbose "Checking $trialUrl"
+        try {
+            $trialResponse = Invoke-WebRequest -Uri $trialUrl -Method HEAD
+            if ($trialResponse.StatusCode -eq 200) {
+                Write-Verbose "Found a match at $trialUrl"
+                return $trialUrl;
+            }
+            else {
+                Write-Verbose "No match at $trialUrl"
+            }
+        }
+        catch {
+            Write-Verbose "Failed to check $trialUrl"
+        }
     }
 }
 
@@ -1025,19 +1040,18 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
     }
     $akaMsLink += "/$Channel"
     if (-not [string]::IsNullOrEmpty($Quality)) {
-        $akaMsLink +="/$Quality"
+        $akaMsLink += "/$Quality"
     }
-    $akaMsLink +="/$Product-win-$Architecture.zip"
+    $akaMsLink += "/$Product-win-$Architecture.zip"
     Say-Verbose  "Constructed aka.ms link: '$akaMsLink'."
-    $akaMsDownloadLink=$null
+    $akaMsDownloadLink = $null
 
-    for ($maxRedirections = 9; $maxRedirections -ge 0; $maxRedirections--)
-    {
+    for ($maxRedirections = 9; $maxRedirections -ge 0; $maxRedirections--) {
         #get HTTP response
         #do not pass credentials as a part of the $akaMsLink and do not apply credentials in the GetHTTPResponse function
         #otherwise the redirect link would have credentials as well
         #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
-        $Response= GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true -DisableFeedCredential $true
+        $Response = GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true -DisableFeedCredential $true
         Say-Verbose "Received response:`n$Response"
 
         if ([string]::IsNullOrEmpty($Response)) {
@@ -1046,14 +1060,18 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
         }
 
         #if HTTP code is 301 (Moved Permanently), the redirect link exists
-        if  ($Response.StatusCode -eq 301)
-        {
+        if ($Response.StatusCode -eq 301) {
             try {
                 $akaMsDownloadLink = $Response.Headers.GetValues("Location")[0]
 
                 if ([string]::IsNullOrEmpty($akaMsDownloadLink)) {
                     Say-Verbose "The link '$akaMsLink' is not valid: server returned 301 (Moved Permanently), but the headers do not contain the redirect location."
                     return $null
+                }
+
+                $actualRedirectUrl = Sanitize-RedirectUrl $akaMsDownloadLink
+                if ($null -ne $actualRedirectUrl) {
+                    $akaMsDownloadLink = $actualRedirectUrl
                 }
 
                 Say-Verbose "The redirect location retrieved: '$akaMsDownloadLink'."
@@ -1066,8 +1084,7 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
                 return $null
             }
         }
-        elseif ((($Response.StatusCode -lt 300) -or ($Response.StatusCode -ge 400)) -and (-not [string]::IsNullOrEmpty($akaMsDownloadLink)))
-        {
+        elseif ((($Response.StatusCode -lt 300) -or ($Response.StatusCode -ge 400)) -and (-not [string]::IsNullOrEmpty($akaMsDownloadLink))) {
             # Redirections have ended.
             return $akaMsDownloadLink
         }
@@ -1084,7 +1101,7 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
 function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $NormalizedQuality, [bool] $Internal, [string] $ProductName, [string] $Architecture) {
     $AkaMsDownloadLink = Get-AkaMSDownloadLink -Channel $NormalizedChannel -Quality $NormalizedQuality -Internal $Internal -Product $ProductName -Architecture $Architecture
    
-    if ([string]::IsNullOrEmpty($AkaMsDownloadLink)){
+    if ([string]::IsNullOrEmpty($AkaMsDownloadLink)) {
         if (-not [string]::IsNullOrEmpty($NormalizedQuality)) {
             # if quality is specified - exit with error - there is no fallback approach
             Say-Error "Failed to locate the latest version in the channel '$NormalizedChannel' with '$NormalizedQuality' quality for '$ProductName', os: 'win', architecture: '$Architecture'."
@@ -1117,11 +1134,12 @@ function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $Normal
     }
 }
 
-function Get-Feeds-To-Use()
-{
+function Get-Feeds-To-Use() {
     $feeds = @(
-    "https://dotnetcli.azureedge.net/dotnet",
-    "https://dotnetbuilds.azureedge.net/public"
+        "https://builds.dotnet.microsoft.com/dotnet"
+        "https://dotnetcli.azureedge.net/dotnet"
+        "https://ci.dot.net/public"
+        "https://dotnetbuilds.azureedge.net/public"
     )
 
     if (-not [string]::IsNullOrEmpty($AzureFeed)) {
@@ -1130,14 +1148,16 @@ function Get-Feeds-To-Use()
 
     if ($NoCdn) {
         $feeds = @(
-        "https://dotnetcli.blob.core.windows.net/dotnet",
-        "https://dotnetbuilds.blob.core.windows.net/public"
+            "https://dotnetcli.blob.core.windows.net/dotnet",
+            "https://dotnetbuilds.blob.core.windows.net/public"
         )
 
         if (-not [string]::IsNullOrEmpty($UncachedFeed)) {
             $feeds = @($UncachedFeed)
         }
     }
+
+    Write-Verbose "Initialized feeds: $feeds"
 
     return $feeds
 }
@@ -1192,8 +1212,7 @@ function Prepare-Install-Directory {
     }
 }
 
-if ($Help)
-{
+if ($Help) {
     Get-Help $PSCommandPath -Examples
     exit
 }
@@ -1241,13 +1260,12 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
     ($DownloadLink, $SpecificVersion, $EffectiveVersion) = Get-AkaMsLink-And-Version $NormalizedChannel $NormalizedQuality $Internal $NormalizedProduct $CLIArchitecture
     
     if ($null -ne $DownloadLink) {
-        $DownloadLinks += New-Object PSObject -Property @{downloadLink="$DownloadLink";specificVersion="$SpecificVersion";effectiveVersion="$EffectiveVersion";type='aka.ms'}
+        $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'aka.ms' }
         Say-Verbose "Generated aka.ms link $DownloadLink with version $EffectiveVersion"
         
         if (-Not $DryRun) {
             Say-Verbose "Checking if the version $EffectiveVersion is already installed"
-            if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion)
-            {
+            if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
                 Say "$assetName with version '$EffectiveVersion' is already installed."
                 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
                 return
@@ -1258,34 +1276,31 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
 
 # Primary and legacy links cannot be used if a quality was specified.
 # If we already have an aka.ms link, no need to search the blob feeds.
-if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count)
-{
+if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count) {
     foreach ($feed in $feeds) {
         try {
             $SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $feed -Channel $Channel -Version $Version -JSonFile $JSonFile
             $DownloadLink, $EffectiveVersion = Get-Download-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
             $LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
             
-            $DownloadLinks += New-Object PSObject -Property @{downloadLink="$DownloadLink";specificVersion="$SpecificVersion";effectiveVersion="$EffectiveVersion";type='primary'}
+            $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'primary' }
             Say-Verbose "Generated primary link $DownloadLink with version $EffectiveVersion"
     
             if (-not [string]::IsNullOrEmpty($LegacyDownloadLink)) {
-                $DownloadLinks += New-Object PSObject -Property @{downloadLink="$LegacyDownloadLink";specificVersion="$SpecificVersion";effectiveVersion="$EffectiveVersion";type='legacy'}
+                $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$LegacyDownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'legacy' }
                 Say-Verbose "Generated legacy link $LegacyDownloadLink with version $EffectiveVersion"
             }
     
             if (-Not $DryRun) {
                 Say-Verbose "Checking if the version $EffectiveVersion is already installed"
-                if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion)
-                {
+                if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
                     Say "$assetName with version '$EffectiveVersion' is already installed."
                     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
                     return
                 }
             }
         }
-        catch
-        {
+        catch {
             Say-Verbose "Failed to acquire download links from feed $feed. Exception: $_"
         }
     }
@@ -1308,8 +1323,7 @@ $DownloadSucceeded = $false
 $DownloadedLink = $null
 $ErrorMessages = @()
 
-foreach ($link in $DownloadLinks)
-{
+foreach ($link in $DownloadLinks) {
     Say-Verbose "Downloading `"$($link.type)`" link $($link.downloadLink)"
 
     try {
@@ -1329,7 +1343,8 @@ foreach ($link in $DownloadLinks)
     
         if ($PSItem.Exception.Data.Contains("ErrorMessage")) {
             $ErrorMessage = $PSItem.Exception.Data["ErrorMessage"]
-        } else {
+        }
+        else {
             $ErrorMessage = $PSItem.Exception.Message
         }
 

--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -1069,11 +1069,6 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
                     return $null
                 }
 
-                $actualRedirectUrl = Sanitize-RedirectUrl $akaMsDownloadLink
-                if ($null -ne $actualRedirectUrl) {
-                    $akaMsDownloadLink = $actualRedirectUrl
-                }
-
                 Say-Verbose "The redirect location retrieved: '$akaMsDownloadLink'."
                 # This may yet be a link to another redirection. Attempt to retrieve the page again.
                 $akaMsLink = $akaMsDownloadLink
@@ -1086,6 +1081,11 @@ function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Intern
         }
         elseif ((($Response.StatusCode -lt 300) -or ($Response.StatusCode -ge 400)) -and (-not [string]::IsNullOrEmpty($akaMsDownloadLink))) {
             # Redirections have ended.
+            $actualRedirectUrl = Sanitize-RedirectUrl $akaMsDownloadLink
+            if ($null -ne $actualRedirectUrl) {
+                $akaMsDownloadLink = $actualRedirectUrl
+            }
+
             return $akaMsDownloadLink
         }
 

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1395,9 +1395,11 @@ get_download_link_from_aka_ms() {
 get_feeds_to_use()
 {
     feeds=(
-    "https://builds.dotnet.microsoft.com/dotnet"
+    "https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet" # direct-access alias for builds.dotnet.microsoft.com until certs are ready for that alias
+    #"https://builds.dotnet.microsoft.com/dotnet"
     "https://dotnetcli.azureedge.net/dotnet"
-    "https://ci.dot.net/public"
+    "https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public" # direct-access alias for ci.dot.net until certs are ready for that alias
+    #"https://ci.dot.net/public"
     "https://dotnetbuilds.azureedge.net/public"
     )
 

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=1.0.5_runtime=dotnet.verified.txt
@@ -1,7 +1,11 @@
 ﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-osx-x64.tar.gz
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-osx-x64.1.0.5.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "1.0.5" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" --runtime "dotnet" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -1,5 +1,7 @@
 ﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
-dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: URL #1 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
+dotnet-install: URL #3 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-osx-x64.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "2.1.0" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" --runtime "aspnetcore" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=6.0.100_runtime=null.verified.txt
@@ -1,7 +1,11 @@
 ﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-osx-x64.tar.gz
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-osx-x64.6.0.100.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "6.0.100" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=8.0.303_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=8.0.303_runtime=null.verified.txt
@@ -1,7 +1,11 @@
 ﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-osx-x64.tar.gz
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-dev-osx-x64.8.0.303.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "8.0.303" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=9.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=9.0.100_runtime=null.verified.txt
@@ -1,7 +1,11 @@
 ﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
 dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-dev-osx-x64.9.0.100.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "9.0.100" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
@@ -1,6 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #4 - primary: https://ci.dot.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "1.0.5" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "dotnet"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=1.0.5_runtime=dotnet.verified.txt
@@ -1,10 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
-dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
 dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
-dotnet-install: URL #4 - primary: https://ci.dot.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
-dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
 dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-runtime-1.0.5-win-x64.zip
 dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Runtime/1.0.5/dotnet-win-x64.1.0.5.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "1.0.5" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "dotnet"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -1,6 +1,6 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
 dotnet-install: URL #1 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
-dotnet-install: URL #2 - primary: https://ci.dot.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #2 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
 dotnet-install: URL #3 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "2.1.0" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "aspnetcore"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=2.1.0_runtime=aspnetcore.verified.txt
@@ -1,4 +1,6 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
-dotnet-install: URL #1 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #1 - primary: https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #2 - primary: https://ci.dot.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
+dotnet-install: URL #3 - primary: https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/2.1.0/aspnetcore-runtime-2.1.0-win-x64.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "2.1.0" -InstallDir "dotnet-sdk" -Architecture "x64" -Runtime "aspnetcore"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
@@ -1,10 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
-dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
 dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
-dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
-dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
 dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
 dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "6.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=6.0.100_runtime=null.verified.txt
@@ -1,6 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/6.0.100/dotnet-dev-win-x64.6.0.100.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "6.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=8.0.303_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=8.0.303_runtime=null.verified.txt
@@ -1,6 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "8.0.303" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=8.0.303_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=8.0.303_runtime=null.verified.txt
@@ -1,10 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
-dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
 dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
-dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
-dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
 dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-sdk-8.0.303-win-x64.zip
 dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/8.0.303/dotnet-dev-win-x64.8.0.303.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "8.0.303" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=9.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=9.0.100_runtime=null.verified.txt
@@ -1,10 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
-dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #0 - primary: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
 dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
 dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
-dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
-dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #4 - primary: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #5 - legacy: https://dotnetbuilds-bgf9bthjbvdca2ar.b02.azurefd.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
 dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
 dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "9.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=9.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=9.0.100_runtime=null.verified.txt
@@ -1,6 +1,10 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
-dotnet-install: URL #1 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
-dotnet-install: URL #2 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
-dotnet-install: URL #3 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #2 - primary: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #3 - legacy: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #4 - primary: https://ci.dot.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #5 - legacy: https://ci.dot.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
+dotnet-install: URL #6 - primary: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip
+dotnet-install: URL #7 - legacy: https://dotnetbuilds.azureedge.net/public/Sdk/9.0.100/dotnet-dev-win-x64.9.0.100.zip
 dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "9.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenMacosIsPassedToBash.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenMacosIsPassedToBash.verified.txt
@@ -1,3 +1,3 @@
 ﻿dotnet-install: Payload URLs:
-dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/%VERSION%/dotnet-sdk-%VERSION%-osx-x64.tar.gz
+dotnet-install: URL #0 - aka.ms: https://dotnetcli-f0e9dzh5e5eze7cd.b02.azurefd.net/dotnet/Sdk/%VERSION%/dotnet-sdk-%VERSION%-osx-x64.tar.gz
 dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "%VERSION%" --install-dir "dotnet-sdk" --architecture "x64" --os "osx"


### PR DESCRIPTION
In preparation for new CDNs for .NET Builds, we are making the scripts resilient to CDN changes.

In the current default mode of execution, the scripts use the channel, quality, and other inputs to look up an aka.ms link that redirects to the current best-known version of the product that the user requested. For example, `./dotnet-install.sh --channel 9.0 --quality ga` might use the url `https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz` when on an x64 Linux host to download the appropriate version of the SDK.

This url used to be accepted wholesale, but with the new CDN and incremental cleanup of various aka.ms links, we cannot rely on 100% data correctness. In order to buffer these changes, instead of directly using the aka.ms redirect, we'll instead use it to probe the set of known feeds and pick the one to use (if any) before falling back to our legacy lookup mechanism.

We'll derive the 'stem' - the portion of the redirect URL unique to the download - and apply that stem to each feed lookup in priority order. The first url that exists will be the one used for the remainder of the download session.

<details>
<summary>Powershell script dry-run for .NET 9 SDK installation</summary>

```console
./dotnet-install.ps1 -Channel 9.0 -Quality ga -DryRun -Verbose
VERBOSE: dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
VERBOSE: dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
VERBOSE: dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
VERBOSE: dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

VERBOSE: dotnet-install: Get-CLIArchitecture-From-Architecture -Architecture "<auto>"
VERBOSE: dotnet-install: Get-Machine-Architecture
VERBOSE: Perform operation 'Enumerate CimInstances' with following parameters, ''className' = CIM_OperatingSystem,'namespaceName' = root\cimv2'.
VERBOSE: Operation 'Enumerate CimInstances' complete.
VERBOSE: dotnet-install: Get-NormalizedQuality -Quality "ga"
VERBOSE: dotnet-install: Normalized quality: ''
VERBOSE: dotnet-install: Get-NormalizedChannel -Channel "9.0"
VERBOSE: dotnet-install: Normalized channel: '9.0'
VERBOSE: dotnet-install: Get-NormalizedProduct -Runtime ""
VERBOSE: dotnet-install: Normalized product: 'dotnet-sdk'
VERBOSE: dotnet-install: Action 'Product discovery' took 0.0689581 seconds
VERBOSE: dotnet-install: Resolve-Installation-Path -InstallDir "<auto>"
VERBOSE: dotnet-install: Get-User-Share-Path
VERBOSE: dotnet-install: InstallRoot: C:\Users\chusk\AppData\Local\Microsoft\dotnet
VERBOSE: Initialized feeds: https://builds.dotnet.microsoft.com/dotnet https://dotnetcli.azureedge.net/dotnet https://ci.dot.net/public https://dotnetbuilds.azureedge.net/public
VERBOSE: dotnet-install: Get-AkaMSDownloadLink -Channel "9.0" -Quality "" -Internal "False" -Product "dotnet-sdk" -Architecture "x64"
VERBOSE: dotnet-install: Retrieving primary payload URL from aka.ms link for channel: '9.0', quality: '' product: 'dotnet-sdk', os: 'win', architecture: 'x64'.
VERBOSE: dotnet-install: Constructed aka.ms link: 'https://aka.ms/dotnet/9.0/dotnet-sdk-win-x64.zip'.
VERBOSE: dotnet-install: Received response:
StatusCode: 301, ReasonPhrase: 'Moved Permanently', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Server: Kestrel
  Location: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
  Request-Context: appId=cid-v1:b47e5e27-bf85-45ba-a97c-0377ce0e5779
  X-Response-Cache-Status: True
  Cache-Control: max-age=0, no-cache, no-store
  Pragma: no-cache
  Date: Fri, 20 Dec 2024 22:44:11 GMT
  Connection: keep-alive
  Strict-Transport-Security: max-age=31536000 ; includeSubDomains
  Content-Length: 0
  Expires: Fri, 20 Dec 2024 22:44:11 GMT
}
VERBOSE: Checking configured feeds for the asset at Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
VERBOSE: Checking https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
VERBOSE: Requested HTTP/1.1 HEAD with 0-byte payload
VERBOSE: Failed to check https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
VERBOSE: Checking https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
VERBOSE: Requested HTTP/1.1 HEAD with 0-byte payload
VERBOSE: Received HTTP/1.1 293042093-byte response of content type application/octet-stream
VERBOSE: Found a match at https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
VERBOSE: dotnet-install: The redirect location retrieved: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip'.
VERBOSE: dotnet-install: Received response:
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Accept-Ranges: bytes
  Age: 94465
  Date: Fri, 20 Dec 2024 22:44:12 GMT
  ETag: 0x8DD13C4375A70B6
  Server: ECAcc (dac/9C73)
  X-Cache: HIT
  x-ms-blob-type: BlockBlob
  x-ms-lease-status: unlocked
  x-ms-request-id: 69f672e3-101e-007e-0254-52f527000000
  x-ms-version: 2009-09-19
  Content-Type: application/octet-stream
  Last-Modified: Tue, 03 Dec 2024 17:59:21 GMT
  Content-Length: 293042093
}
VERBOSE: dotnet-install: Retrieved primary named payload URL from aka.ms link: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip'.
VERBOSE: dotnet-install: Downloading using legacy url will not be attempted.
VERBOSE: dotnet-install: Version: '9.0.101'.
VERBOSE: dotnet-install: Get-Product-Version -SpecificVersion "9.0.101" -PackageDownloadLink "https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip"
VERBOSE: dotnet-install: Get-Product-Version-Url -Flattened "True" -AzureFeed "" -SpecificVersion "9.0.101" -PackageDownloadLink "https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip"
VERBOSE: dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
VERBOSE: dotnet-install: Get-Product-Version-Url -Flattened "False" -AzureFeed "" -SpecificVersion "9.0.101" -PackageDownloadLink "https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip"
VERBOSE: dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/productVersion.txt
VERBOSE: dotnet-install: Checking for the existence of https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
VERBOSE: dotnet-install: Product version: '9.0.101'.
VERBOSE: dotnet-install: Generated aka.ms link https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip with version 9.0.101
dotnet-install: Payload URLs:
dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip
dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "9.0.101" -InstallDir "C:\Users\chusk\AppData\Local\Microsoft\dotnet" -Architecture "x64" -Verbose "True"
```
</details>

<details>
<summary>Bash script dry-run for .NET 9 SDK installation</summary>

```console
./dotnet-install.sh --channel 9.0 --quality ga --dry-run --verbose
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Calling: machine_has curl
dotnet-install: Calling: calculate_vars
dotnet-install: Calling: get_normalized_architecture_from_architecture <auto>
dotnet-install: Calling: get_machine_architecture
dotnet-install: Normalized architecture: 'x64'.
dotnet-install: Calling: get_normalized_os
dotnet-install: Calling: get_current_os_name
dotnet-install: Calling: get_linux_platform_name
dotnet-install: Normalized OS: 'linux'.
dotnet-install: Calling: get_normalized_quality ga
dotnet-install: Normalized quality: ''.
dotnet-install: Calling: get_normalized_channel 9.0
dotnet-install: Normalized channel: '9.0'.
dotnet-install: Calling: get_normalized_product
dotnet-install: Normalized product: 'dotnet-sdk'.
dotnet-install: Calling: resolve_installation_path <auto>
dotnet-install: Calling: get_user_install_path
dotnet-install: resolve_installation_path: user_install_path=/home/chethusk/.dotnet
dotnet-install: InstallRoot: '/home/chethusk/.dotnet'.
dotnet-install: Calling: get_normalized_architecture_for_specific_sdk_version Latest 9.0 x64
dotnet-install: Calling: get_current_os_name
dotnet-install: Calling: get_linux_platform_name
dotnet-install: Calling: get_download_link_from_aka_ms
dotnet-install: Retrieving primary payload URL from aka.ms for channel: '9.0', quality: '', product: 'dotnet-sdk', os: 'linux', architecture: 'x64'.
dotnet-install: Constructed aka.ms link: 'https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz'.
dotnet-install: Calling: get_http_header https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz true
dotnet-install: Calling: machine_has curl
dotnet-install: Calling: get_http_header_curl https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz true
dotnet-install: Received response: HTTP/1.1 301 Moved Permanently
Server: Kestrel
Location: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
Request-Context: appId=cid-v1:d94c0f68-64bf-4036-8409-a0e761bb7ee1
X-Response-Cache-Status: True
Content-Length: 0
Expires: Fri, 20 Dec 2024 22:32:26 GMT
Cache-Control: max-age=0, no-cache, no-store
Pragma: no-cache
Date: Fri, 20 Dec 2024 22:32:26 GMT
Connection: keep-alive
Strict-Transport-Security: max-age=31536000 ; includeSubDomains

HTTP/2 200
accept-ranges: bytes
age: 99445
content-md5: CIgc/eLDVx/WFrmmkqQj+w==
content-type: application/octet-stream
date: Fri, 20 Dec 2024 22:32:26 GMT
etag: 0x8DD13C4389CAD29
last-modified: Tue, 03 Dec 2024 17:59:24 GMT
server: ECAcc (dac/9C4B)
x-cache: HIT
x-ms-blob-type: BlockBlob
x-ms-lease-status: unlocked
x-ms-request-id: 9e02f845-301e-0056-6647-52948f000000
x-ms-version: 2009-09-19
content-length: 210346874

dotnet-install: Calling: sanitize_redirect_url https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking configured feeds for the asset at Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: check_url_exists https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: machine_has curl
dotnet-install: No match at https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: check_url_exists https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: machine_has curl
dotnet-install: Found a match at https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: The redirect location retrieved: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz'.
dotnet-install: Retrieved primary payload URL from aka.ms link: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz'.
dotnet-install: Downloading using legacy url will not be attempted.
dotnet-install: Version: '9.0.101'.
dotnet-install: Calling: get_specific_product_version  9.0.101 https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: get_specific_product_version_url  9.0.101 true https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url  9.0.101 false https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: Generated 1 links.
dotnet-install: Link 0: aka.ms, 9.0.101, https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Payload URLs:
dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "9.0.101" --install-dir "/home/chethusk/.dotnet" --architecture "x64" --os "linux" --verbose
chethusk@Chet-Desktop:/mnt/e/Code/dotnet-install-scripts/src$ ./dotnet-install.sh --channel 9.0 --quality ga --dry-run --verbose
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Calling: machine_has curl
dotnet-install: Calling: calculate_vars
dotnet-install: Calling: get_normalized_architecture_from_architecture <auto>
dotnet-install: Calling: get_machine_architecture
dotnet-install: Normalized architecture: 'x64'.
dotnet-install: Calling: get_normalized_os
dotnet-install: Calling: get_current_os_name
dotnet-install: Calling: get_linux_platform_name
dotnet-install: Normalized OS: 'linux'.
dotnet-install: Calling: get_normalized_quality ga
dotnet-install: Normalized quality: ''.
dotnet-install: Calling: get_normalized_channel 9.0
dotnet-install: Normalized channel: '9.0'.
dotnet-install: Calling: get_normalized_product
dotnet-install: Normalized product: 'dotnet-sdk'.
dotnet-install: Calling: resolve_installation_path <auto>
dotnet-install: Calling: get_user_install_path
dotnet-install: resolve_installation_path: user_install_path=/home/chethusk/.dotnet
dotnet-install: InstallRoot: '/home/chethusk/.dotnet'.
dotnet-install: Calling: get_normalized_architecture_for_specific_sdk_version Latest 9.0 x64
dotnet-install: Calling: get_current_os_name
dotnet-install: Calling: get_linux_platform_name
dotnet-install: Calling: get_download_link_from_aka_ms
dotnet-install: Retrieving primary payload URL from aka.ms for channel: '9.0', quality: '', product: 'dotnet-sdk', os: 'linux', architecture: 'x64'.
dotnet-install: Constructed aka.ms link: 'https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz'.
dotnet-install: Calling: get_http_header https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz true
dotnet-install: Calling: machine_has curl
dotnet-install: Calling: get_http_header_curl https://aka.ms/dotnet/9.0/dotnet-sdk-linux-x64.tar.gz true
dotnet-install: Received response: HTTP/1.1 301 Moved Permanently
Server: Kestrel
Location: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
Request-Context: appId=cid-v1:d94c0f68-64bf-4036-8409-a0e761bb7ee1
X-Response-Cache-Status: True
Content-Length: 0
Expires: Fri, 20 Dec 2024 22:45:17 GMT
Cache-Control: max-age=0, no-cache, no-store
Pragma: no-cache
Date: Fri, 20 Dec 2024 22:45:17 GMT
Connection: keep-alive
Strict-Transport-Security: max-age=31536000 ; includeSubDomains

HTTP/2 200
accept-ranges: bytes
age: 100216
content-md5: CIgc/eLDVx/WFrmmkqQj+w==
content-type: application/octet-stream
date: Fri, 20 Dec 2024 22:45:17 GMT
etag: 0x8DD13C4389CAD29
last-modified: Tue, 03 Dec 2024 17:59:24 GMT
server: ECAcc (dac/9C4B)
x-cache: HIT
x-ms-blob-type: BlockBlob
x-ms-lease-status: unlocked
x-ms-request-id: 9e02f845-301e-0056-6647-52948f000000
x-ms-version: 2009-09-19
content-length: 210346874

dotnet-install: Calling: sanitize_redirect_url https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking configured feeds for the asset at Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: check_url_exists https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: machine_has curl
dotnet-install: No match at https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Checking https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: check_url_exists https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: machine_has curl
dotnet-install: Found a match at https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: The redirect location retrieved: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz'.
dotnet-install: Retrieved primary payload URL from aka.ms link: 'https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz'.
dotnet-install: Downloading using legacy url will not be attempted.
dotnet-install: Version: '9.0.101'.
dotnet-install: Calling: get_specific_product_version  9.0.101 https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Calling: get_specific_product_version_url  9.0.101 true https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
dotnet-install: Calling: get_specific_product_version_url  9.0.101 false https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Constructed productVersion link: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/productVersion.txt
dotnet-install: Checking for the existence of https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/sdk-productVersion.txt
dotnet-install: Calling: machine_has curl
dotnet-install: Generated 1 links.
dotnet-install: Link 0: aka.ms, 9.0.101, https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Payload URLs:
dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz
dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "9.0.101" --install-dir "/home/chethusk/.dotnet" --architecture "x64" --os "linux" --verbose
```
</details>