### PR TITLE
Remove support for Signed and Validated qualities

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -28,7 +28,7 @@
     Warning: Value "Current" is deprecated for the Channel parameter. Use "STS" instead.
     Note: The version parameter overrides the channel parameter when any version other than 'latest' is used.
 .PARAMETER Quality
-    Download the latest build of specified quality in the channel. The possible values are: daily, signed, validated, preview, GA.
+    Download the latest build of specified quality in the channel. The possible values are: daily, preview, GA.
     Works only in combination with channel. Not applicable for STS and LTS channels and will be ignored if those channels are used. 
     For SDK use channel in A.B.Cxx format: using quality together with channel in A.B format is not supported.
     Supported since 5.0 release.
@@ -300,10 +300,10 @@ function Get-NormalizedQuality([string]$Quality) {
     }
 
     switch ($Quality) {
-        { @("daily", "signed", "validated", "preview") -contains $_ } { return $Quality.ToLowerInvariant() }
+        { @("daily", "preview") -contains $_ } { return $Quality.ToLowerInvariant() }
         #ga quality is available without specifying quality, so normalizing it to empty
         { $_ -eq "ga" } { return "" }
-        default { throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+        default { throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
     }
 }
 

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -477,7 +477,7 @@ get_normalized_quality() {
     local quality="$(to_lowercase "$1")"
     if [ ! -z "$quality" ]; then
         case "$quality" in
-            daily | signed | validated | preview)
+            daily | preview)
                 echo "$quality"
                 return 0
                 ;;
@@ -486,7 +486,7 @@ get_normalized_quality() {
                 return 0
                 ;;
             *)
-                say_err "'$quality' is not a supported value for --quality option. Supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
+                say_err "'$quality' is not a supported value for --quality option. Supported values are: daily, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
                 return 1
                 ;;
         esac
@@ -1788,7 +1788,7 @@ do
             echo "              examples: 2.0.0-preview2-006120; 1.1.0"
             echo "  -q,--quality <quality>         Download the latest build of specified quality in the channel."
             echo "      -Quality"
-            echo "          The possible values are: daily, signed, validated, preview, GA."
+            echo "          The possible values are: daily, preview, GA."
             echo "          Works only in combination with channel. Not applicable for STS and LTS channels and will be ignored if those channels are used." 
             echo "          For SDK use channel in A.B.Cxx format. Using quality for SDK together with channel in A.B format is not supported." 
             echo "          Supported since 5.0 release." 

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -175,20 +175,13 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        [InlineData("5.0.2xx", null, false, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
        [InlineData("STS", null, false, @"https://aka.ms/dotnet/STS/dotnet-sdk-")]
        [InlineData("LTS", null, false, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
-       [InlineData("5.0.2xx", "signed", false, @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
        [InlineData("5.0.2xx", "daily", false, @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
-       [InlineData("5.0.2xx", "validated", false, @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
        [InlineData("5.0.2xx", "preview", false, @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
        [InlineData("5.0.2xx", "ga", false, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
        [InlineData("3.1", null, true, @"https://aka.ms/dotnet/internal/3.1/dotnet-sdk-")]
        [InlineData("5.0.2xx", null, true, @"https://aka.ms/dotnet/internal/5.0.2xx/dotnet-sdk-")]
        [InlineData("STS", null, true, @"https://aka.ms/dotnet/internal/STS/dotnet-sdk-")]
        [InlineData("LTS", null, true, @"https://aka.ms/dotnet/internal/LTS/dotnet-sdk-")]
-       [InlineData("5.0.2xx", "validated", true, @"https://aka.ms/dotnet/internal/5.0.2xx/validated/dotnet-sdk-")]
-       [InlineData("6.0.2xx", "validated", true, @"https://aka.ms/dotnet/internal/6.0.2xx/validated/dotnet-sdk-")]
-       [InlineData("7.0.1xx", "validated", true, @"https://aka.ms/dotnet/internal/7.0.1xx/validated/dotnet-sdk-")]
-       [InlineData("8.0.3xx", "validated", true, @"https://aka.ms/dotnet/internal/8.0.3xx/validated/dotnet-sdk-")]
-       [InlineData("9.0.1xx", "validated", true, @"https://aka.ms/dotnet/internal/9.0.1xx/validated/dotnet-sdk-")]
        public void LinkCanBeCreatedForSdk(string channel, string quality, bool isInternal, string expectedLink)
        {
            string expectedLinkPattern = Regex.Escape(expectedLink);

--- a/tests/Install-Scripts.Test/AkaMsLinksTests.cs
+++ b/tests/Install-Scripts.Test/AkaMsLinksTests.cs
@@ -27,15 +27,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        //[InlineData("5.0.2xx", null, @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
        //[InlineData("STS", null, @"https://aka.ms/dotnet/STS/dotnet-sdk-")]
        //[InlineData("LTS", null, @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
-       //[InlineData("5.0.2xx", "signed", @"https://aka.ms/dotnet/5.0.2xx/signed/dotnet-sdk-")]
        //[InlineData("5.0.2xx", "daily", @"https://aka.ms/dotnet/5.0.2xx/daily/dotnet-sdk-")]
-       //[InlineData("5.0.2xx", "validated", @"https://aka.ms/dotnet/5.0.2xx/validated/dotnet-sdk-")]
        //[InlineData("5.0.2xx", "preview", @"https://aka.ms/dotnet/5.0.2xx/preview/dotnet-sdk-")]
        //[InlineData("5.0.2xx", "ga", @"https://aka.ms/dotnet/5.0.2xx/dotnet-sdk-")]
         
-       // 6.0 doesn't have a signed. validated, preview or ga build yet.
-       // [InlineData("6.0", "signed", @"https://aka.ms/dotnet/6.0/signed/dotnet-sdk-")]
-       //[InlineData("6.0", "validated", @"https://aka.ms/dotnet/6.0/validated/dotnet-sdk-")]
        //[InlineData("6.0", "preview", @"https://aka.ms/dotnet/6.0/preview/dotnet-sdk-")]
        //[InlineData("6.0", "ga", @"https://aka.ms/dotnet/6.0/dotnet-sdk-")]
 
@@ -91,9 +86,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        //[InlineData("5.0", "dotnet", null, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
        //[InlineData("STS", "dotnet", null, @"https://aka.ms/dotnet/STS/dotnet-runtime-")]
        //[InlineData("LTS", "dotnet", null, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
-       //[InlineData("5.0", "dotnet", "signed", @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
        //[InlineData("5.0", "dotnet", "daily", @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
-       //[InlineData("5.0", "dotnet", "validated", @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
        //[InlineData("5.0", "dotnet", "preview", @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
        //[InlineData("5.0", "dotnet", "ga", @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
        //[InlineData("2.0", "aspnetcore", null, @"https://aka.ms/dotnet/2.0/aspnetcore-runtime-")]
@@ -103,9 +96,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        //[InlineData("5.0", "aspnetcore", null, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
        //[InlineData("STS", "aspnetcore", null, @"https://aka.ms/dotnet/STS/aspnetcore-runtime-")]
        //[InlineData("LTS", "aspnetcore", null, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
-       //[InlineData("5.0", "aspnetcore", "signed", @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
        //[InlineData("5.0", "aspnetcore", "daily", @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
-       //[InlineData("5.0", "aspnetcore", "validated", @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
        //[InlineData("5.0", "aspnetcore", "preview", @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
        //[InlineData("5.0", "aspnetcore", "ga", @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
        //[InlineData("3.0", "windowsdesktop", null, @"https://aka.ms/dotnet/3.0/windowsdesktop-runtime-")]
@@ -113,15 +104,10 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        //[InlineData("5.0", "windowsdesktop", null, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
        //[InlineData("STS", "windowsdesktop", null, @"https://aka.ms/dotnet/STS/windowsdesktop-runtime-")]
        //[InlineData("LTS", "windowsdesktop", null, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
-       //[InlineData("5.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
        //[InlineData("5.0", "windowsdesktop", "daily", @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
-       //[InlineData("5.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
        //[InlineData("5.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
        //[InlineData("5.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
 
-       // 6.0 doesn't have a signed. validated, preview or ga build yet.
-       // [InlineData("6.0", "windowsdesktop", "signed", @"https://aka.ms/dotnet/6.0/signed/windowsdesktop-runtime-")]
-       // [InlineData("6.0", "windowsdesktop", "validated", @"https://aka.ms/dotnet/6.0/validated/windowsdesktop-runtime-")]
        // [InlineData("6.0", "windowsdesktop", "preview", @"https://aka.ms/dotnet/6.0/preview/windowsdesktop-runtime-")]
        // [InlineData("6.0", "windowsdesktop", "ga", @"https://aka.ms/dotnet/6.0/windowsdesktop-runtime-")]
         
@@ -229,9 +215,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        [InlineData("5.0", "dotnet", null, false, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
        [InlineData("STS", "dotnet", null, false, @"https://aka.ms/dotnet/STS/dotnet-runtime-")]
        [InlineData("LTS", "dotnet", null, false, @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
-       [InlineData("5.0", "dotnet", "signed", false, @"https://aka.ms/dotnet/5.0/signed/dotnet-runtime-")]
        [InlineData("5.0", "dotnet", "daily", false, @"https://aka.ms/dotnet/5.0/daily/dotnet-runtime-")]
-       [InlineData("5.0", "dotnet", "validated", false, @"https://aka.ms/dotnet/5.0/validated/dotnet-runtime-")]
        [InlineData("5.0", "dotnet", "preview", false, @"https://aka.ms/dotnet/5.0/preview/dotnet-runtime-")]
        [InlineData("5.0", "dotnet", "ga", false, @"https://aka.ms/dotnet/5.0/dotnet-runtime-")]
        [InlineData("2.1", "aspnetcore", null, false, @"https://aka.ms/dotnet/2.1/aspnetcore-runtime-")]
@@ -239,18 +223,14 @@ namespace Microsoft.DotNet.InstallationScript.Tests
        [InlineData("5.0", "aspnetcore", null, false, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
        [InlineData("STS", "aspnetcore", null, false, @"https://aka.ms/dotnet/STS/aspnetcore-runtime-")]
        [InlineData("LTS", "aspnetcore", null, false, @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
-       [InlineData("5.0", "aspnetcore", "signed", false, @"https://aka.ms/dotnet/5.0/signed/aspnetcore-runtime-")]
        [InlineData("5.0", "aspnetcore", "daily", false, @"https://aka.ms/dotnet/5.0/daily/aspnetcore-runtime-")]
-       [InlineData("5.0", "aspnetcore", "validated", false, @"https://aka.ms/dotnet/5.0/validated/aspnetcore-runtime-")]
        [InlineData("5.0", "aspnetcore", "preview", false, @"https://aka.ms/dotnet/5.0/preview/aspnetcore-runtime-")]
        [InlineData("5.0", "aspnetcore", "ga", false, @"https://aka.ms/dotnet/5.0/aspnetcore-runtime-")]
        [InlineData("3.1", "windowsdesktop", null, false, @"https://aka.ms/dotnet/3.1/windowsdesktop-runtime-")]
        [InlineData("5.0", "windowsdesktop", null, false, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
        [InlineData("STS", "windowsdesktop", null, false, @"https://aka.ms/dotnet/STS/windowsdesktop-runtime-")]
        [InlineData("LTS", "windowsdesktop", null, false, @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
-       [InlineData("5.0", "windowsdesktop", "signed", false, @"https://aka.ms/dotnet/5.0/signed/windowsdesktop-runtime-")]
        [InlineData("5.0", "windowsdesktop", "daily", false, @"https://aka.ms/dotnet/5.0/daily/windowsdesktop-runtime-")]
-       [InlineData("5.0", "windowsdesktop", "validated", false, @"https://aka.ms/dotnet/5.0/validated/windowsdesktop-runtime-")]
        [InlineData("5.0", "windowsdesktop", "preview", false,  @"https://aka.ms/dotnet/5.0/preview/windowsdesktop-runtime-")]
        [InlineData("5.0", "windowsdesktop", "ga", false, @"https://aka.ms/dotnet/5.0/windowsdesktop-runtime-")]
        [InlineData("LTS", "dotnet", null, true, @"https://aka.ms/dotnet/internal/LTS/dotnet-runtime-")]
@@ -312,12 +292,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
        [Theory]
        [InlineData("STS", null, "daily", @"https://aka.ms/dotnet/STS/dotnet-sdk-")]
-       [InlineData("LTS", null, "signed", @"https://aka.ms/dotnet/LTS/dotnet-sdk-")]
-       [InlineData("STS", "dotnet", "validated", @"https://aka.ms/dotnet/STS/dotnet-runtime-")]
        [InlineData("LTS", "dotnet", "preview", @"https://aka.ms/dotnet/LTS/dotnet-runtime-")]
        [InlineData("STS", "aspnetcore", "daily", @"https://aka.ms/dotnet/STS/aspnetcore-runtime-")]
-       [InlineData("LTS", "aspnetcore", "signed", @"https://aka.ms/dotnet/LTS/aspnetcore-runtime-")]
-       [InlineData("STS", "windowsdesktop", "validated", @"https://aka.ms/dotnet/STS/windowsdesktop-runtime-")]
        [InlineData("LTS", "windowsdesktop", "preview", @"https://aka.ms/dotnet/LTS/windowsdesktop-runtime-")]
        public void QualityIsSkippedForLTSAndCurrentChannel(string channel, string runtime, string quality, string expectedLink)
        {
@@ -355,9 +331,9 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
        [Theory]
        [InlineData("Fake", null, "daily")]
-       [InlineData("Fake", "dotnet", "validated")]
+       [InlineData("Fake", "dotnet", "daily")]
        [InlineData("Fake", "aspnetcore", "daily")]
-       [InlineData("Fake", "windowsdesktop", "validated")]
+       [InlineData("Fake", "windowsdesktop", "daily")]
        public void NoFallbackIfQualityIsGiven(string channel, string runtime, string quality)
        {
            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && runtime == "windowsdesktop")

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -547,7 +547,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
         [Theory]
         [InlineData("8.0.303", Quality.Daily)]
-        [InlineData("9.0.100", Quality.Signed)]
         public void WhenBothVersionAndQualityWereSpecified(string version, Quality quality)
         {
             var args = GetInstallScriptArgs(null, null, quality.ToString(), _sdkInstallationDirectory, version: version);
@@ -560,7 +559,6 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         }
 
         [Theory]
-        [InlineData(null, Quality.Signed)]
         [InlineData("8.0.303", null)]
         public void WhenEitherVersionOrQualityWasSpecified(string? version, Quality? quality)
         {

--- a/tests/Install-Scripts.Test/Utils/Quality.cs
+++ b/tests/Install-Scripts.Test/Utils/Quality.cs
@@ -9,10 +9,8 @@ namespace Install_Scripts.Test.Utils
     {
         None = 0,
         Daily = 1,
-        Signed = 2,
-        Validated = 4,
         Preview = 8,
         Ga = 16,
-        All = Daily | Signed | Validated | Preview | Ga,
+        All = Daily | Preview | Ga,
     }
 }


### PR DESCRIPTION
After looking at usage data for the aka.ms links that back these qualities, it's clear that the only usage is from the tests in the install scripts repo itself. Removing these links has significant benefit to the overall time it takes to run our staging pipelines, as well as overall maintainability.