### PR TITLE
add support for .NET 10.0 preview versions in tests

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -61,7 +61,7 @@ stages:
         command: test
 
   - job: MacOSTests
-    timeoutInMinutes: 30
+    timeoutInMinutes: 45
     pool: 
       vmImage: 'macOS-latest'
     steps:

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -39,10 +39,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("STS", "9\\.0\\..*", Quality.None),
                 ("9.0", "9\\.0\\..*", Quality.None),
                 ("9.0", "9\\.0\\..*", Quality.Ga),
-                // 10 not available yet
-                //("10.0", "10\\.0\\..*", Quality.None),
-                //("10.0", "10\\.0\\..*", Quality.Preview),
-                //("10.0", "10\\.0\\..*", Quality.Ga),
+                ("10.0", "10\\.0\\..*", Quality.Preview),
             };
 
         /// <summary>
@@ -65,6 +62,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("7.0", "7\\.0\\..*", Quality.None),
                 ("8.0", "8\\.0\\..*", Quality.None),
                 ("9.0", "9\\.0\\..*", Quality.None),
+                ("10.0", "10\\.0\\..*", Quality.Preview),
             };
 
         /// <summary>
@@ -88,6 +86,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
                 ("7.0.1xx", "7\\.0\\..*", Quality.Daily),
                 ("8.0.1xx", "8\\.0\\..*", Quality.Daily),
                 ("9.0.1xx", "9\\.0\\..*", Quality.Daily),
+                ("10.0.1xx", "10\\.0\\..*", Quality.Preview),
             };
 
         public static IEnumerable<object?[]> InstallSdkFromChannelTestCases
@@ -371,6 +370,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.100-alpha.1.22054.9")]
         [InlineData("8.0.404")]
         [InlineData("9.0.100")]
+        [InlineData("10.0.100-preview.3.25201.16")]
         public void WhenInstallingASpecificVersionOfTheSdk(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -400,6 +400,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21528.8")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
+        [InlineData("10.0.0-preview.3.25171.5")]
         public void WhenInstallingASpecificVersionOfDotnetRuntime(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -429,6 +430,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21567.15")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
+        [InlineData("10.0.0-preview.3.25172.1")]
         public void WhenInstallingASpecificVersionOfAspNetCoreRuntime(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -459,6 +461,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21472.1")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
+        [InlineData("10.0.0-preview.3.25174.1")]
         public void WhenInstallingASpecificVersionOfWindowsdesktopRuntime(string version)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
closes #586

increased timeout for macos tests, because we're hitting it in ~20% cases already and this PR adds more cases