### PR TITLE
Handle curl 8.14.0 zero-exit bug

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1208,7 +1208,7 @@ downloadcurl() {
 
     # Regression in curl causes curl with --retry to return a 0 exit code even when it fails to download a file - https://github.com/curl/curl/issues/17554
     if [ $curl_exit_code -eq 0 ] && echo "$curl_output" | grep -q "^curl: ([0-9]*) "; then
-        curl_exit_code=$(echo "$curl_output" | grep "^curl: ([0-9]*) " | sed 's/curl: (\([0-9]*\)).*/\1/')
+        curl_exit_code=$(echo "$curl_output" | sed 's/curl: (\([0-9]*\)).*/\1/')
     fi
 
     if [ $curl_exit_code -gt 0 ]; then

--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1198,13 +1198,19 @@ downloadcurl() {
     local curl_options="--retry 20 --retry-delay 2 --connect-timeout 15 -sSL -f --create-dirs "
     local curl_exit_code=0;
     if [ -z "$out_path" ]; then
-        curl $curl_options "$remote_path_with_credential" 2>&1
+        curl_output=$(curl $curl_options "$remote_path_with_credential" 2>&1)
         curl_exit_code=$?
+        echo "$curl_output"
     else
-        curl $curl_options -o "$out_path" "$remote_path_with_credential" 2>&1
+        curl_output=$(curl $curl_options -o "$out_path" "$remote_path_with_credential" 2>&1)
         curl_exit_code=$?
     fi
-    
+
+    # Regression in curl causes curl with --retry to return a 0 exit code even when it fails to download a file - https://github.com/curl/curl/issues/17554
+    if [ $curl_exit_code -eq 0 ] && echo "$curl_output" | grep -q "^curl: ([0-9]*) "; then
+        curl_exit_code=$(echo "$curl_output" | grep "^curl: ([0-9]*) " | sed 's/curl: (\([0-9]*\)).*/\1/')
+    fi
+
     if [ $curl_exit_code -gt 0 ]; then
         download_error_msg="Unable to download $remote_path."
         # Check for curl timeout codes


### PR DESCRIPTION
Fixes https://github.com/dotnet/install-scripts/issues/610
Related to https://github.com/curl/curl/issues/17554.

Curl 8.14.0 was returning a zero-exit code even when the output indicated a failure, such as curl: (22) The requested URL returned error: 404. This behavior resulted in failures as described in https://github.com/dotnet/install-scripts/issues/610.