### PR TITLE
guard unset http_code/download_error_msg

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -1169,11 +1169,11 @@ download() {
             exit 1
         fi
 
-        if [ "$failed" = false ] || [ $attempts -ge 3 ] || { [ ! -z $http_code ] && [ $http_code = "404" ]; }; then
+        if [ "$failed" = false ] || [ $attempts -ge 3 ] || { [ -n "${http_code-}" ] && [ "${http_code}" = "404" ]; }; then
             break
         fi
 
-        say "Download attempt #$attempts has failed: $http_code $download_error_msg"
+        say "Download attempt #$attempts has failed: ${http_code-} ${download_error_msg-}"
         say "Attempt #$((attempts+1)) will start in $((attempts*10)) seconds."
         sleep $((attempts*10))
     done
@@ -1580,12 +1580,12 @@ install_dotnet() {
         download "$download_link" "$zip_path" 2>&1 || download_failed=true
 
         if [ "$download_failed" = true ]; then
-            case $http_code in
+            case ${http_code-} in
             404)
                 say "The resource at $link_type link '$download_link' is not available."
                 ;;
             *)
-                say "Failed to download $link_type link '$download_link': $http_code $download_error_msg"
+                say "Failed to download $link_type link '$download_link': ${http_code-} ${download_error_msg-}"
                 ;;
             esac
             rm -f "$zip_path" 2>&1 && say_verbose "Temporary archive file $zip_path was removed"


### PR DESCRIPTION
Closes https://github.com/dotnet/install-scripts/issues/626

When a download attempt using curl exited with timeout codes (7 or 28), `http_code` was unset and later referenced in the retry loop. This caused the following error: line 1172: `http_code: unbound variable`

#### Validation of changes:
1. Created a mock curl earlier in PATH that always exits with code 28 (timeout) and prints a timeout-like stderr line.
1. Ran `PATH=/path/to/mockbin:$PATH bash ./src/dotnet-install.sh --channel 9.0`
- Before fix: saw http_code: unbound variable.
- After fix: no unbound error; script performed retries and failed gracefully with:
`Download attempt #1 has failed:  Unable to download ... Failed to reach the server: connection timeout.`