### PR TITLE
Specify code owners for install-dotnet-preview script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 # @dotnet/install-scripts-maintainers will be requested
 # for review when someone opens a pull request.
 * @dotnet/install-scripts-maintainers
+
+# The preview script is not owned by the maintainers of this repo
+/src/install-dotnet-preview.sh @dotnet/dotnet-install-preview-contributors


### PR DESCRIPTION
Related to https://github.com/dotnet/install-scripts/issues/635

Add CODEOWNERS entry for the preview install script.

This entry should be removed with https://github.com/dotnet/install-scripts/issues/636