### PR TITLE
Add missing variable quoting

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -661,7 +661,7 @@ parse_globaljson_file_for_version() {
         return 1
     fi
 
-    sdk_section=$(cat $json_file | tr -d "\r" | awk '/"sdk"/,/}/')
+    sdk_section=$(cat "$json_file" | tr -d "\r" | awk '/"sdk"/,/}/')
     if [ -z "$sdk_section" ]; then
         say_err "Unable to parse the SDK node in \`$json_file\`"
         return 1


### PR DESCRIPTION
All other uses of `json_file` are quoted, and not doing so here breaks the call to `cat` if the path has spaces in it.