### PR TITLE
Fix integration tests for .NET 10 GA release

### DIFF
--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=10.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToBash_version=10.0.100_runtime=null.verified.txt
@@ -1,0 +1,7 @@
+﻿dotnet_install: Warning: Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead.
+dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-osx-x64.tar.gz
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-dev-osx-x64.10.0.100.tar.gz
+dotnet-install: URL #2 - primary: https://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk-10.0.100-osx-x64.tar.gz
+dotnet-install: URL #3 - legacy: https://ci.dot.net/public/Sdk/10.0.100/dotnet-dev-osx-x64.10.0.100.tar.gz
+dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "10.0.100" --install-dir "dotnet-sdk" --architecture "x64" --os "osx" -runtimeid "osx"

--- a/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=10.0.100_runtime=null.verified.txt
+++ b/tests/Install-Scripts.Test/Assets/GivenThatIWantToGetTheSdkLinksFromAScript.WhenAnExactVersionIsPassedToPowershell_version=10.0.100_runtime=null.verified.txt
@@ -1,0 +1,6 @@
+﻿dotnet-install: Payload URLs:
+dotnet-install: URL #0 - primary: https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x64.zip
+dotnet-install: URL #1 - legacy: https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-dev-win-x64.10.0.100.zip
+dotnet-install: URL #2 - primary: https://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x64.zip
+dotnet-install: URL #3 - legacy: https://ci.dot.net/public/Sdk/10.0.100/dotnet-dev-win-x64.10.0.100.zip
+dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "10.0.100" -InstallDir "dotnet-sdk" -Architecture "x64"

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -108,6 +108,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("8.0", "dotnet", true)]
         [InlineData("9.0", "dotnet")]
         [InlineData("9.0", "dotnet", true)]
+        [InlineData("10.0", "dotnet")]
+        [InlineData("10.0", "dotnet", true)]
         [InlineData("STS", "dotnet")]
         [InlineData("LTS", "dotnet")]
         [InlineData("master", "dotnet")]
@@ -135,6 +137,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("8.0", "aspnetcore", true)]
         [InlineData("9.0", "aspnetcore")]
         [InlineData("9.0", "aspnetcore", true)]
+        [InlineData("10.0", "aspnetcore")]
+        [InlineData("10.0", "aspnetcore", true)]
         [InlineData("master", "aspnetcore")]
         [InlineData("release/2.1", "aspnetcore")]
         [InlineData("release/2.2", "aspnetcore")]
@@ -156,6 +160,8 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("8.0", "windowsdesktop", true)]
         [InlineData("9.0", "windowsdesktop")]
         [InlineData("9.0", "windowsdesktop", true)]
+        [InlineData("10.0", "windowsdesktop")]
+        [InlineData("10.0", "windowsdesktop", true)]
         [InlineData("master", "windowsdesktop")]
         [InlineData("master", "windowsdesktop", true)]
         public void WhenChannelResolvesToASpecificRuntimeVersion(string channel, string runtimeType, bool useCustomFeedCredential = false)
@@ -205,6 +211,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0")]
         [InlineData("8.0")]
         [InlineData("9.0")]
+        [InlineData("10.0")]
         [InlineData("STS")]
         [InlineData("LTS")]
         [InlineData("master")]
@@ -338,6 +345,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("6.0.100", null)]
         [InlineData("8.0.303", null)]
         [InlineData("9.0.100", null)]
+        [InlineData("10.0.100", null)]
         public async Task WhenAnExactVersionIsPassedToBash(string version, string runtime)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -410,6 +418,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("6.0.100", null)]
         [InlineData("8.0.303", null)]
         [InlineData("9.0.100", null)]
+        [InlineData("10.0.100", null)]
         public async Task WhenAnExactVersionIsPassedToPowershell(string version, string? runtime)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -375,7 +375,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.100-alpha.1.22054.9")]
         [InlineData("8.0.404")]
         [InlineData("9.0.100")]
-        [InlineData("10.0.100-preview.3.25201.16")]
+        [InlineData("10.0.100")]
         public void WhenInstallingASpecificVersionOfTheSdk(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -405,7 +405,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21528.8")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
-        [InlineData("10.0.0-preview.3.25171.5")]
+        [InlineData("10.0.0")]
         public void WhenInstallingASpecificVersionOfDotnetRuntime(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -435,7 +435,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21567.15")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
-        [InlineData("10.0.0-preview.3.25172.1")]
+        [InlineData("10.0.0")]
         public void WhenInstallingASpecificVersionOfAspNetCoreRuntime(string version, string? effectiveVersion = null)
         {
             // Run install script to download and install.
@@ -466,7 +466,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.0-alpha.1.21472.1")]
         [InlineData("8.0.11")]
         [InlineData("9.0.0")]
-        [InlineData("10.0.0-preview.3.25174.1")]
+        [InlineData("10.0.0")]
         public void WhenInstallingASpecificVersionOfWindowsdesktopRuntime(string version)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -494,6 +494,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("7.0.100-alpha.1.22054.9")]
         [InlineData("8.0.11", null, "aspnetcore")]
         [InlineData("9.0.0", null, "aspnetcore")]
+        [InlineData("10.0.0", null, "aspnetcore")]
         [InlineData("5.0.13-servicing.21552.32", "5.0.13", "aspnetcore")]
         [InlineData("6.0.0-preview.4.21176.7", null, "aspnetcore")]
         [InlineData("7.0.0-alpha.1.21567.15", null, "aspnetcore")]


### PR DESCRIPTION
Fixes #658

Fixes recently failing tests (e.g. [Run 20251113.1](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1201767&view=ms.vss-test-web.build-test-results-tab)) by updating the test data to reflect that .NET 10 is the most recent LTS version.

Example of failed test output:

```
Expected _commandResult.StdOut to match regex "\ \ 8.0..\ [(/private)?/tmp/InstallScript-Tests/rv5cjri5.ovx/sdk]" because Matching the command output failed. Pattern: \ \ 8.0..\ [(/private)?/tmp/InstallScript-Tests/rv5cjri5.ovx/sdk]


File Name: /bin/bash
Arguments: -c "/tmp/InstallScript-Tests/rv5cjri5.ovx/dotnet --info"
Exit Code: 0
StdOut:
.NET SDK:
Version:           10.0.100
Commit:            b0f34d51fc
Workload version:  10.0.100-manifests.4c0ca8ba
MSBuild version:   18.0.2+b0f34d51f
```