### PR TITLE
Pass on inner exception in GivenThatIWantToInstallDotnetFromAScript.Dispose()

### DIFF
--- a/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToInstallDotnetFromAScript.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
             }
             catch (UnauthorizedAccessException e)
             {
-                throw new Exception($"Failed to remove {_sdkInstallationDirectory}");
+                throw new Exception($"Failed to remove {_sdkInstallationDirectory}", e);
             }
         }
 


### PR DESCRIPTION
Fixes #659

This also fixes `warning CS0168: The variable 'e' is declared but never used`