### PR TITLE
Fix Mac official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -130,10 +130,10 @@ extends:
             command: test
 
       - job: MacOSTests
-        timeoutInMinutes: 30
+        timeoutInMinutes: 45
         pool: 
           name: Azure Pipelines
-          image: macOS-13
+          image: macos-latest
           os: macOS
         steps:
         - checkout: self


### PR DESCRIPTION
Fixes https://github.com/dotnet/install-scripts/issues/663

Mac PR builds were already running on macos-latest with a 45 minute timeout.