### PR TITLE
Pass -UseBasicParsing for Invoke-WebRequest calls in powershell

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -185,7 +185,7 @@ function Measure-Action($name, $block) {
 
 function Get-Remote-File-Size($zipUri) {
     try {
-        $response = Invoke-WebRequest -Uri $zipUri -Method Head
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $zipUri -Method Head
         $fileSize = $response.Headers["Content-Length"]
         if ((![string]::IsNullOrEmpty($fileSize))) {
             Say "Remote file $zipUri size is $fileSize bytes."


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/122393 and https://support.microsoft.com/en-gb/topic/powershell-5-1-preventing-script-execution-from-web-content-7cb95559-655e-43fd-a8bd-ceef2406b705