### PR TITLE
Validate channel format in dotnet-install.sh

### DIFF
--- a/src/dotnet-install.sh
+++ b/src/dotnet-install.sh
@@ -524,8 +524,16 @@ get_normalized_channel() {
                 return 0
                 ;;
             *)
-                echo "$channel"
-                return 0
+                if [[ "$channel" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                    echo "$channel"
+                    return 0
+                elif [[ "$channel" =~ ^[0-9]+\.[0-9]+\.[0-9]+[a-z]{2}$ ]]; then
+                    echo "$channel"
+                    return 0
+                else
+                    say_err "'$1' is not a supported value for --channel option. Supported values are: STS, LTS, a 2-part version in A.B format (e.g., 10.0), or a 3-part SDK band version in A.B.Cxx format (e.g., 5.0.1xx). If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
+                    return 1
+                fi
                 ;;
         esac
     fi

--- a/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
+++ b/tests/Install-Scripts.Test/GivenThatIWantToGetTheSdkLinksFromAScript.cs
@@ -305,6 +305,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
         [InlineData("release/2.6.1xx")]
         [InlineData("4.8.2")]
         [InlineData("abcdefg")]
+        [InlineData("10")]
         public void WhenInvalidChannelWasUsed(string channel)
         {
             string feedCredentials = Guid.NewGuid().ToString();
@@ -314,7 +315,7 @@ namespace Microsoft.DotNet.InstallationScript.Tests
 
             //  Standard 'dryrun' criterion
             commandResult.Should().Fail();
-            commandResult.Should().HaveStdErrContaining("Failed to resolve the exact version number.");
+            commandResult.Should().HaveStdErrContaining("is not a supported value for --channel option.");
             commandResult.Should().NotHaveStdOutContaining("Repeatable invocation:");
             commandResult.Should().NotHaveStdOutContainingIgnoreCase(feedCredentials);
             commandResult.Should().NotHaveStdErrContainingIgnoreCase(feedCredentials);


### PR DESCRIPTION
## Summary

Fixes #686

When an unsupported channel format is provided (e.g., `-c 10`), the script now exits early with a clear error message instead of proceeding to construct invalid URLs that fail with confusing 404 errors.

### Changes

- **`src/dotnet-install.sh`**: Added channel format validation in `get_normalized_channel()`. The wildcard case now validates that the channel matches either a 2-part version (`A.B`, e.g., `10.0`) or a 3-part SDK band version (`A.B.Cxx`, e.g., `5.0.1xx`). Invalid formats produce a clear error message listing supported formats, following the same pattern used by `get_normalized_quality()`.

- **`tests/.../GivenThatIWantToGetTheSdkLinksFromAScript.cs`**: Added `[InlineData("10")]` test case and updated the expected error message assertion to match the new validation message.

### Before

```
$ bash dotnet-install.sh -c 10 --verbose
# ... attempts to download from invalid URLs, gets 404
# "Failed to resolve the exact version number."
```

### After

```
$ bash dotnet-install.sh -c 10
# "'10' is not a supported value for --channel option. Supported values are:
#  STS, LTS, a 2-part version in A.B format (e.g., 10.0), or a 3-part SDK
#  band version in A.B.Cxx format (e.g., 5.0.1xx)."
```