### PR TITLE
Add validate-install-scripts skill for release process

### DIFF
--- a/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
+++ b/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
@@ -1,0 +1,181 @@
+<#
+.SYNOPSIS
+    Checks CI status on validation PRs and closes them when CI passes.
+
+.DESCRIPTION
+    This script checks the CI status of previously opened validation PRs
+    (identified by commit SHA) and closes PRs where all required checks have passed.
+
+.PARAMETER CommitSha
+    The full commit SHA that was used when opening the validation PRs.
+
+.PARAMETER Repos
+    Optional list of target repos. Defaults to: aspnetcore, arcade, sdk, runtime, winforms.
+
+.PARAMETER AutoClose
+    If set, automatically close PRs where checks have passed. Otherwise, prompts for confirmation.
+
+.EXAMPLE
+    ./Close-ValidationPRs.ps1 -CommitSha "5147e32300a8e908f5d737c8cff63a76b4b63531"
+
+.EXAMPLE
+    ./Close-ValidationPRs.ps1 -CommitSha "5147e32300a8e908f5d737c8cff63a76b4b63531" -AutoClose
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CommitSha,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$Repos = @("aspnetcore", "arcade", "sdk", "runtime", "winforms"),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AutoClose
+)
+
+$ErrorActionPreference = "Stop"
+
+$ShortSha = $CommitSha.Substring(0, 8)
+$BranchName = "validate-install-scripts/$ShortSha"
+
+function Find-ValidationPR {
+    param([string]$RepoName)
+
+    $repo = "dotnet/$RepoName"
+    $ghUser = gh api user --jq '.login'
+
+    # Check direct branch first
+    $prJson = gh pr list --repo $repo --head $BranchName --state open --json number,url,headRefName 2>$null
+    $prs = $prJson | ConvertFrom-Json
+
+    # If not found, check fork-based branch
+    if (-not $prs -or $prs.Count -eq 0) {
+        $prJson = gh pr list --repo $repo --head "${ghUser}:${BranchName}" --state open --json number,url,headRefName 2>$null
+        $prs = $prJson | ConvertFrom-Json
+    }
+
+    if ($prs -and $prs.Count -gt 0) {
+        return @{
+            Repo = $repo
+            Number = $prs[0].number
+            Url = $prs[0].url
+        }
+    }
+    return $null
+}
+
+function Get-PRCheckStatus {
+    param([string]$Repo, [int]$Number)
+
+    $checksJson = gh pr checks --repo $Repo $Number --json name,state,conclusion 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return "unknown"
+    }
+
+    $checks = $checksJson | ConvertFrom-Json
+    if (-not $checks -or $checks.Count -eq 0) {
+        return "no-checks"
+    }
+
+    $failed = $checks | Where-Object { $_.conclusion -eq "FAILURE" -or $_.conclusion -eq "ERROR" }
+    $pending = $checks | Where-Object { $_.state -eq "PENDING" -or $_.state -eq "QUEUED" -or $_.state -eq "IN_PROGRESS" }
+
+    if ($failed.Count -gt 0) {
+        return "failed"
+    }
+    elseif ($pending.Count -gt 0) {
+        return "pending"
+    }
+    else {
+        return "passed"
+    }
+}
+
+# --- Main ---
+Write-Host "Validate Install Scripts - Check & Close PRs" -ForegroundColor Cyan
+Write-Host "Commit: $CommitSha" -ForegroundColor Cyan
+Write-Host "Branch: $BranchName" -ForegroundColor Cyan
+Write-Host ""
+
+$results = @()
+
+foreach ($repoName in $Repos) {
+    $pr = Find-ValidationPR -RepoName $repoName
+
+    if (-not $pr) {
+        $results += [PSCustomObject]@{
+            Repo = "dotnet/$repoName"
+            Status = "not-found"
+            Url = ""
+            Number = 0
+        }
+        continue
+    }
+
+    $status = Get-PRCheckStatus -Repo $pr.Repo -Number $pr.Number
+    $results += [PSCustomObject]@{
+        Repo = $pr.Repo
+        Status = $status
+        Url = $pr.Url
+        Number = $pr.Number
+    }
+}
+
+# Display status table
+Write-Host "`n=== CI Status ===" -ForegroundColor Cyan
+foreach ($r in $results) {
+    $icon = switch ($r.Status) {
+        "passed" { "[PASS]" }
+        "failed" { "[FAIL]" }
+        "pending" { "[WAIT]" }
+        "not-found" { "[----]" }
+        default { "[????]" }
+    }
+    $color = switch ($r.Status) {
+        "passed" { "Green" }
+        "failed" { "Red" }
+        "pending" { "Yellow" }
+        default { "Gray" }
+    }
+    $urlDisplay = if ($r.Url) { $r.Url } else { "No PR found" }
+    Write-Host "  $icon $($r.Repo): $urlDisplay" -ForegroundColor $color
+}
+
+# Close passed PRs
+$passedPRs = $results | Where-Object { $_.Status -eq "passed" }
+if ($passedPRs.Count -gt 0) {
+    Write-Host "`n=== Closing Passed PRs ===" -ForegroundColor Cyan
+
+    foreach ($pr in $passedPRs) {
+        if (-not $AutoClose) {
+            $confirm = Read-Host "  Close $($pr.Repo) PR #$($pr.Number)? [Y/n]"
+            if ($confirm -eq "n" -or $confirm -eq "N") {
+                Write-Host "  Skipped." -ForegroundColor Yellow
+                continue
+            }
+        }
+
+        gh pr close --repo $pr.Repo $pr.Number --delete-branch --comment "CI passed. Closing validation PR."
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Closed: $($pr.Url)" -ForegroundColor Green
+        }
+        else {
+            Write-Warning "  Failed to close PR #$($pr.Number) in $($pr.Repo)"
+        }
+    }
+}
+
+# Report pending
+$pendingPRs = $results | Where-Object { $_.Status -eq "pending" }
+if ($pendingPRs.Count -gt 0) {
+    Write-Host "`nSome PRs still have pending checks. Re-run this script later to check again." -ForegroundColor Yellow
+}
+
+# Report failures
+$failedPRs = $results | Where-Object { $_.Status -eq "failed" }
+if ($failedPRs.Count -gt 0) {
+    Write-Host "`nSome PRs have failed checks. Investigate the failures:" -ForegroundColor Red
+    foreach ($pr in $failedPRs) {
+        Write-Host "  $($pr.Url)" -ForegroundColor Red
+    }
+}

--- a/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
+++ b/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
@@ -78,14 +78,18 @@ function Get-PRCheckStatus {
     }
 
     $passed = ($checks | Where-Object { $_.state -eq "SUCCESS" -or $_.state -eq "NEUTRAL" -or $_.state -eq "SKIPPED" }).Count
-    $failed = ($checks | Where-Object { $_.state -eq "FAILURE" -or $_.state -eq "ERROR" -or $_.state -eq "CANCELLED" }).Count
+    $failed = ($checks | Where-Object { $_.state -eq "FAILURE" -or $_.state -eq "ERROR" }).Count
     $pending = ($checks | Where-Object { $_.state -eq "PENDING" -or $_.state -eq "QUEUED" -or $_.state -eq "IN_PROGRESS" }).Count
+    $cancelled = ($checks | Where-Object { $_.state -eq "CANCELLED" }).Count
 
+    # CANCELLED jobs are ambiguous (could be superseded runs or dependent jobs that didn't execute).
+    # Only report "failed" for actual FAILURE/ERROR states.
     $status = if ($failed -gt 0) { "failed" }
               elseif ($pending -gt 0) { "pending" }
+              elseif ($cancelled -gt 0) { "cancelled" }
               else { "passed" }
 
-    return @{ Status = $status; Pass = $passed; Fail = $failed; Pending = $pending }
+    return @{ Status = $status; Pass = $passed; Fail = $failed; Pending = $pending; Cancelled = $cancelled }
 }
 
 # --- Main ---
@@ -118,6 +122,7 @@ foreach ($repoName in $Repos) {
         Pass = $checkResult.Pass
         Fail = $checkResult.Fail
         Pending = $checkResult.Pending
+        Cancelled = $checkResult.Cancelled
     }
 }
 
@@ -128,6 +133,7 @@ foreach ($r in $results) {
         "passed" { "[PASS]" }
         "failed" { "[FAIL]" }
         "pending" { "[WAIT]" }
+        "cancelled" { "[CNCL]" }
         "not-found" { "[----]" }
         default { "[????]" }
     }
@@ -135,11 +141,14 @@ foreach ($r in $results) {
         "passed" { "Green" }
         "failed" { "Red" }
         "pending" { "Yellow" }
+        "cancelled" { "DarkYellow" }
         default { "Gray" }
     }
     $urlDisplay = if ($r.Url) { $r.Url } else { "No PR found" }
     $counts = if ($r.Status -ne "not-found" -and $r.Status -ne "unknown") {
-        " ($($r.Pass) pass, $($r.Fail) fail, $($r.Pending) pending)"
+        $parts = @("$($r.Pass) pass", "$($r.Fail) fail", "$($r.Pending) pending")
+        if ($r.Cancelled -gt 0) { $parts += "$($r.Cancelled) cancelled" }
+        " (" + ($parts -join ", ") + ")"
     } else { "" }
     Write-Host "  $icon $($r.Repo):$counts $urlDisplay" -ForegroundColor $color
 }

--- a/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
+++ b/.github/skills/validate-install-scripts/Close-ValidationPRs.ps1
@@ -67,28 +67,25 @@ function Find-ValidationPR {
 function Get-PRCheckStatus {
     param([string]$Repo, [int]$Number)
 
-    $checksJson = gh pr checks --repo $Repo $Number --json name,state,conclusion 2>&1
+    $checksJson = gh pr checks --repo $Repo $Number --json name,state 2>&1
     if ($LASTEXITCODE -ne 0) {
-        return "unknown"
+        return @{ Status = "unknown"; Pass = 0; Fail = 0; Pending = 0 }
     }
 
     $checks = $checksJson | ConvertFrom-Json
     if (-not $checks -or $checks.Count -eq 0) {
-        return "no-checks"
+        return @{ Status = "no-checks"; Pass = 0; Fail = 0; Pending = 0 }
     }
 
-    $failed = $checks | Where-Object { $_.conclusion -eq "FAILURE" -or $_.conclusion -eq "ERROR" }
-    $pending = $checks | Where-Object { $_.state -eq "PENDING" -or $_.state -eq "QUEUED" -or $_.state -eq "IN_PROGRESS" }
+    $passed = ($checks | Where-Object { $_.state -eq "SUCCESS" -or $_.state -eq "NEUTRAL" -or $_.state -eq "SKIPPED" }).Count
+    $failed = ($checks | Where-Object { $_.state -eq "FAILURE" -or $_.state -eq "ERROR" -or $_.state -eq "CANCELLED" }).Count
+    $pending = ($checks | Where-Object { $_.state -eq "PENDING" -or $_.state -eq "QUEUED" -or $_.state -eq "IN_PROGRESS" }).Count
 
-    if ($failed.Count -gt 0) {
-        return "failed"
-    }
-    elseif ($pending.Count -gt 0) {
-        return "pending"
-    }
-    else {
-        return "passed"
-    }
+    $status = if ($failed -gt 0) { "failed" }
+              elseif ($pending -gt 0) { "pending" }
+              else { "passed" }
+
+    return @{ Status = $status; Pass = $passed; Fail = $failed; Pending = $pending }
 }
 
 # --- Main ---
@@ -112,12 +109,15 @@ foreach ($repoName in $Repos) {
         continue
     }
 
-    $status = Get-PRCheckStatus -Repo $pr.Repo -Number $pr.Number
+    $checkResult = Get-PRCheckStatus -Repo $pr.Repo -Number $pr.Number
     $results += [PSCustomObject]@{
         Repo = $pr.Repo
-        Status = $status
+        Status = $checkResult.Status
         Url = $pr.Url
         Number = $pr.Number
+        Pass = $checkResult.Pass
+        Fail = $checkResult.Fail
+        Pending = $checkResult.Pending
     }
 }
 
@@ -138,7 +138,10 @@ foreach ($r in $results) {
         default { "Gray" }
     }
     $urlDisplay = if ($r.Url) { $r.Url } else { "No PR found" }
-    Write-Host "  $icon $($r.Repo): $urlDisplay" -ForegroundColor $color
+    $counts = if ($r.Status -ne "not-found" -and $r.Status -ne "unknown") {
+        " ($($r.Pass) pass, $($r.Fail) fail, $($r.Pending) pending)"
+    } else { "" }
+    Write-Host "  $icon $($r.Repo):$counts $urlDisplay" -ForegroundColor $color
 }
 
 # Close passed PRs

--- a/.github/skills/validate-install-scripts/Open-ValidationPRs.ps1
+++ b/.github/skills/validate-install-scripts/Open-ValidationPRs.ps1
@@ -81,8 +81,8 @@ function Open-ValidationPR {
     $Repo = "dotnet/$RepoName"
     Write-Host "`n=== Processing $Repo ===" -ForegroundColor Cyan
 
-    # Get default branch
-    $defaultBranch = gh repo view $Repo --json defaultBranchRef --jq '.defaultBranchRef.name'
+    # Get default branch (REST API — more reliable than GraphQL-based `gh repo view`)
+    $defaultBranch = gh api "repos/$Repo" --jq '.default_branch' 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Failed to get default branch for $Repo. Skipping."
         return $null
@@ -96,13 +96,26 @@ function Open-ValidationPR {
         Write-Host "  Push access confirmed." -ForegroundColor Green
     }
     else {
-        Write-Host "  No push access. Forking..." -ForegroundColor Yellow
-        gh repo fork $Repo --clone=false 2>$null
+        Write-Host "  No push access. Using fork..." -ForegroundColor Yellow
         $ghUser = gh api user --jq '.login'
         $targetRepo = "$ghUser/$RepoName"
         $prHead = "${ghUser}:${BranchName}"
-        # Sync fork
-        gh repo sync $targetRepo --branch $defaultBranch 2>$null
+
+        # Check if fork already exists; if not, create it via REST API
+        $forkExists = gh api "repos/$targetRepo" --jq '.full_name' 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  Creating fork..." -ForegroundColor Yellow
+            gh api "repos/$Repo/forks" --method POST -f "default_branch_only=true" --jq '.full_name' 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "  Failed to create fork of $Repo. Skipping."
+                return $null
+            }
+            # Wait briefly for fork to be ready
+            Start-Sleep -Seconds 5
+        }
+
+        # Sync fork's default branch with upstream
+        gh api "repos/$targetRepo/merge-upstream" --method POST -f "branch=$defaultBranch" 2>$null
         Write-Host "  Using fork: $targetRepo" -ForegroundColor Yellow
     }
 
@@ -226,7 +239,22 @@ Changes:
         --draft `
         --body $prBody
 
-    if ($LASTEXITCODE -eq 0) {
+    if ($LASTEXITCODE -ne 0) {
+        # gh pr create uses GraphQL which can timeout on large repos.
+        # Fall back to REST API for PR creation.
+        Write-Host "  GraphQL PR creation failed. Falling back to REST API..." -ForegroundColor Yellow
+        $prJson = @{
+            title = "[DO NOT MERGE] Install Scripts Update Validation PR"
+            head  = $prHead
+            base  = $defaultBranch
+            body  = $prBody
+            draft = $true
+        } | ConvertTo-Json -Compress
+
+        $prUrl = $prJson | gh api "repos/$Repo/pulls" --method POST --input - --jq '.html_url'
+    }
+
+    if ($LASTEXITCODE -eq 0 -and $prUrl) {
         Write-Host "  PR opened: $prUrl" -ForegroundColor Green
         return $prUrl
     }

--- a/.github/skills/validate-install-scripts/Open-ValidationPRs.ps1
+++ b/.github/skills/validate-install-scripts/Open-ValidationPRs.ps1
@@ -1,0 +1,264 @@
+<#
+.SYNOPSIS
+    Opens validation PRs in key .NET repos to test install script changes.
+
+.DESCRIPTION
+    This script automates the "Validation in Key Repos" step of the install scripts
+    release process. It opens draft PRs in target repos that replace the production
+    install script URL with a raw GitHub URL pointing to a specific commit.
+
+    If the user lacks push access to a target repo, the script automatically forks
+    the repo and creates a cross-fork PR.
+
+.PARAMETER CommitSha
+    The full commit SHA from dotnet/install-scripts to validate.
+
+.PARAMETER Repos
+    Optional list of target repos. Defaults to: aspnetcore, arcade, sdk, runtime, winforms.
+
+.EXAMPLE
+    ./Open-ValidationPRs.ps1 -CommitSha "5147e32300a8e908f5d737c8cff63a76b4b63531"
+
+.EXAMPLE
+    ./Open-ValidationPRs.ps1 -CommitSha "5147e32300a8e908f5d737c8cff63a76b4b63531" -Repos @("arcade", "sdk")
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CommitSha,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$Repos = @("aspnetcore", "arcade", "sdk", "runtime", "winforms")
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProductionShUrl = 'https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.sh'
+$ProductionPs1Url = 'https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.ps1'
+$TestShUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/$CommitSha/src/dotnet-install.sh"
+$TestPs1Url = "https://raw.githubusercontent.com/dotnet/install-scripts/$CommitSha/src/dotnet-install.ps1"
+
+$ShortSha = $CommitSha.Substring(0, 8)
+$BranchName = "validate-install-scripts/$ShortSha"
+
+function Test-GhCli {
+    if (-not (Get-Command "gh" -ErrorAction SilentlyContinue)) {
+        Write-Error "The 'gh' CLI is required but not found. Install from https://cli.github.com/"
+        exit 1
+    }
+    $authStatus = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "gh CLI is not authenticated. Run 'gh auth login' first."
+        exit 1
+    }
+}
+
+function Test-CommitExists {
+    param([string]$Sha)
+    $result = gh api "repos/dotnet/install-scripts/commits/$Sha" --jq '.sha' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Commit $Sha not found in dotnet/install-scripts. Verify the SHA is correct."
+        exit 1
+    }
+    Write-Host "Verified commit exists: $Sha" -ForegroundColor Green
+}
+
+function Get-FileContent {
+    param([string]$Repo, [string]$Path, [string]$Ref)
+    $response = gh api "repos/$Repo/contents/${Path}?ref=$Ref" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to fetch $Path from $Repo at ref $Ref"
+        return $null
+    }
+    $contentBase64 = $response | ConvertFrom-Json | Select-Object -ExpandProperty content
+    # Decode base64 — preserve exact bytes
+    [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($contentBase64))
+}
+
+function Open-ValidationPR {
+    param([string]$RepoName)
+
+    $Repo = "dotnet/$RepoName"
+    Write-Host "`n=== Processing $Repo ===" -ForegroundColor Cyan
+
+    # Get default branch
+    $defaultBranch = gh repo view $Repo --json defaultBranchRef --jq '.defaultBranchRef.name'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to get default branch for $Repo. Skipping."
+        return $null
+    }
+
+    # Check push access
+    $hasPush = gh api "repos/$Repo" --jq '.permissions.push' 2>$null
+    if ($hasPush -eq "true") {
+        $targetRepo = $Repo
+        $prHead = $BranchName
+        Write-Host "  Push access confirmed." -ForegroundColor Green
+    }
+    else {
+        Write-Host "  No push access. Forking..." -ForegroundColor Yellow
+        gh repo fork $Repo --clone=false 2>$null
+        $ghUser = gh api user --jq '.login'
+        $targetRepo = "$ghUser/$RepoName"
+        $prHead = "${ghUser}:${BranchName}"
+        # Sync fork
+        gh repo sync $targetRepo --branch $defaultBranch 2>$null
+        Write-Host "  Using fork: $targetRepo" -ForegroundColor Yellow
+    }
+
+    # Check if branch/PR already exists
+    $branchExists = gh api "repos/$targetRepo/git/ref/heads/$BranchName" 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  Branch already exists." -ForegroundColor Yellow
+        $existingPr = gh pr list --repo $Repo --head $prHead --state open --json url --jq '.[0].url'
+        if ($existingPr) {
+            Write-Host "  PR already exists: $existingPr" -ForegroundColor Green
+            return $existingPr
+        }
+    }
+    else {
+        # Create branch
+        $baseSha = gh api "repos/$targetRepo/git/ref/heads/$defaultBranch" --jq '.object.sha'
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "  Failed to get base SHA. Skipping $Repo."
+            return $null
+        }
+
+        $null = gh api "repos/$targetRepo/git/refs" -f "ref=refs/heads/$BranchName" -f "sha=$baseSha"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "  Failed to create branch. Skipping $Repo."
+            return $null
+        }
+        Write-Host "  Branch created from $defaultBranch"
+    }
+
+    # Fetch files from upstream (always read from dotnet/ org, not fork)
+    $toolsShContent = Get-FileContent -Repo $Repo -Path "eng/common/tools.sh" -Ref $defaultBranch
+    $toolsPs1Content = Get-FileContent -Repo $Repo -Path "eng/common/tools.ps1" -Ref $defaultBranch
+
+    if (-not $toolsShContent -or -not $toolsPs1Content) {
+        Write-Warning "  Failed to fetch file contents. Skipping $Repo."
+        return $null
+    }
+
+    # Verify and replace in tools.sh
+    $shMatches = ([regex]::Matches($toolsShContent, [regex]::Escape($ProductionShUrl))).Count
+    if ($shMatches -ne 1) {
+        Write-Warning "  Expected 1 match in tools.sh, found $shMatches. File format may have changed. Skipping."
+        return $null
+    }
+    $updatedSh = $toolsShContent.Replace($ProductionShUrl, $TestShUrl)
+
+    # Verify and replace in tools.ps1
+    $ps1Matches = ([regex]::Matches($toolsPs1Content, [regex]::Escape($ProductionPs1Url))).Count
+    if ($ps1Matches -ne 1) {
+        Write-Warning "  Expected 1 match in tools.ps1, found $ps1Matches. File format may have changed. Skipping."
+        return $null
+    }
+    $updatedPs1 = $toolsPs1Content.Replace($ProductionPs1Url, $TestPs1Url)
+
+    # Create blobs using base64 to preserve exact bytes
+    $shBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($updatedSh))
+    $ps1Base64 = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($updatedPs1))
+
+    $shBlob = gh api "repos/$targetRepo/git/blobs" --method POST -f "encoding=base64" -f "content=$shBase64" --jq '.sha'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "  Failed to create tools.sh blob. Skipping $Repo."
+        return $null
+    }
+
+    $ps1Blob = gh api "repos/$targetRepo/git/blobs" --method POST -f "encoding=base64" -f "content=$ps1Base64" --jq '.sha'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "  Failed to create tools.ps1 blob. Skipping $Repo."
+        return $null
+    }
+
+    # Get base tree and create atomic commit
+    $baseSha = gh api "repos/$targetRepo/git/ref/heads/$BranchName" --jq '.object.sha'
+    $baseTree = gh api "repos/$targetRepo/git/commits/$baseSha" --jq '.tree.sha'
+
+    $treeJson = @{
+        base_tree = $baseTree
+        tree = @(
+            @{ path = "eng/common/tools.sh"; mode = "100755"; type = "blob"; sha = $shBlob }
+            @{ path = "eng/common/tools.ps1"; mode = "100644"; type = "blob"; sha = $ps1Blob }
+        )
+    } | ConvertTo-Json -Depth 3 -Compress
+
+    $newTree = $treeJson | gh api "repos/$targetRepo/git/trees" --method POST --input - --jq '.sha'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "  Failed to create tree. Skipping $Repo."
+        return $null
+    }
+
+    $commitJson = @{
+        message = "Validate install scripts from dotnet/install-scripts@$ShortSha"
+        tree = $newTree
+        parents = @($baseSha)
+    } | ConvertTo-Json -Depth 3 -Compress
+
+    $newCommit = $commitJson | gh api "repos/$targetRepo/git/commits" --method POST --input - --jq '.sha'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "  Failed to create commit. Skipping $Repo."
+        return $null
+    }
+
+    # Update branch ref
+    $null = gh api "repos/$targetRepo/git/refs/heads/$BranchName" --method PATCH -f "sha=$newCommit"
+
+    # Open draft PR
+    $prBody = @"
+This PR validates install script changes from dotnet/install-scripts commit ``$CommitSha``.
+
+**Do not merge this PR.** It will be closed once CI passes.
+
+Install scripts commit: https://github.com/dotnet/install-scripts/commit/$CommitSha
+
+Changes:
+- ``eng/common/tools.sh``: Points to test install script
+- ``eng/common/tools.ps1``: Points to test install script
+"@
+
+    $prUrl = gh pr create --repo $Repo `
+        --base $defaultBranch `
+        --head $prHead `
+        --title "[DO NOT MERGE] Install Scripts Update Validation PR" `
+        --draft `
+        --body $prBody
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  PR opened: $prUrl" -ForegroundColor Green
+        return $prUrl
+    }
+    else {
+        Write-Warning "  Failed to create PR for $Repo."
+        return $null
+    }
+}
+
+# --- Main ---
+Write-Host "Validate Install Scripts - Open PRs" -ForegroundColor Cyan
+Write-Host "Commit: $CommitSha" -ForegroundColor Cyan
+Write-Host "Branch: $BranchName" -ForegroundColor Cyan
+Write-Host ""
+
+Test-GhCli
+Test-CommitExists -Sha $CommitSha
+
+$results = @{}
+foreach ($repo in $Repos) {
+    $prUrl = Open-ValidationPR -RepoName $repo
+    $results[$repo] = $prUrl
+}
+
+# Summary
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+foreach ($repo in $Repos) {
+    $url = $results[$repo]
+    if ($url) {
+        Write-Host "  dotnet/${repo}: $url" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  dotnet/${repo}: FAILED" -ForegroundColor Red
+    }
+}

--- a/.github/skills/validate-install-scripts/SKILL.md
+++ b/.github/skills/validate-install-scripts/SKILL.md
@@ -9,283 +9,90 @@ description: >
 # Validate Install Scripts in Key Repos
 
 This skill automates the "Validation in Key Repos" step of the install scripts release process.
-It opens PRs titled `[DO NOT MERGE] Install Scripts Update Validation PR` in key .NET repos
+It opens draft PRs titled `[DO NOT MERGE] Install Scripts Update Validation PR` in key .NET repos
 that replace the production install script URL with a raw GitHub URL pointing to a specific commit.
 
 ## Prerequisites
 
 - The `gh` CLI must be authenticated with permissions to create branches and PRs in the target repos.
 - The commit SHA must exist in the `dotnet/install-scripts` repository on GitHub.
+- If the user lacks push access to a target repo, the scripts automatically fork and create cross-fork PRs.
 
-## Quick Start (Preferred)
-
-If PowerShell (Core or Windows PowerShell) is available, use the scripts directly:
-
-```powershell
-# Open validation PRs
-./.github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>"
-
-# Later, check CI and close passed PRs
-./.github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>"
-
-# To auto-close without prompting:
-./.github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>" -AutoClose
-
-# To target specific repos only:
-./.github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>" -Repos @("arcade", "sdk")
-```
-
-If PowerShell is not available, follow the manual steps below using the `gh` CLI directly.
-
-## Modes
+## Usage
 
 ### Mode 1: Open Validation PRs
 
-**When to use:** After pushing install script changes that need validation across repos.
+Ask the user for the commit SHA, then run:
 
-**Input required:** A commit SHA from `dotnet/install-scripts` to validate.
-
-**Steps:**
-
-1. Ask the user for the commit SHA to validate (or accept it as input).
-
-2. Verify the commit exists on GitHub:
-```bash
-gh api "repos/dotnet/install-scripts/commits/<COMMIT_SHA>" --jq '.sha'
+```powershell
+pwsh .github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>"
 ```
 
-3. For each target repository, use `gh` CLI to:
-   a. Check if a branch/PR already exists for this SHA (handle idempotency)
-   b. Create a new branch named `validate-install-scripts/<short-sha>`
-   c. Modify both `eng/common/tools.sh` and `eng/common/tools.ps1` in a single commit
-   d. Open a PR with title `[DO NOT MERGE] Install Scripts Update Validation PR`
+To target specific repos only:
 
-4. Report all opened PR URLs to the user.
+```powershell
+pwsh .github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>" -Repos @("arcade", "sdk")
+```
 
-**Target repositories:**
+### Mode 2: Check CI Status and Close PRs
+
+Ask the user for the same commit SHA used to open the PRs, then run:
+
+```powershell
+pwsh .github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>"
+```
+
+To auto-close without prompting:
+
+```powershell
+pwsh .github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>" -AutoClose
+```
+
+## Target Repositories
+
 - `dotnet/aspnetcore`
 - `dotnet/arcade`
 - `dotnet/sdk`
 - `dotnet/runtime`
 - `dotnet/winforms`
 
-**URL replacements:**
+## What the Scripts Do
 
-In `eng/common/tools.sh`, find the line containing the install script URL assignment:
-```bash
-# Find (the URL assignment line — contains this literal text):
-local install_script_url="https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.sh"
+Both scripts use the `gh` CLI and GitHub's Git Data API. The open script:
 
-# Replace the entire line with:
-local install_script_url="https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.sh"
+1. Verifies the commit exists in `dotnet/install-scripts`
+2. For each target repo:
+   - Checks push access; if denied, forks the repo automatically
+   - Creates a branch named `validate-install-scripts/<short-sha>`
+   - Fetches `eng/common/tools.sh` and `eng/common/tools.ps1`
+   - Replaces the production URL with the raw GitHub URL for the given commit
+   - Creates an atomic commit (both files in one commit) via the Git Data API
+   - Opens a draft PR
+
+The close script:
+
+1. Finds open validation PRs by branch name (handles both direct and fork-based PRs)
+2. Checks CI status on each
+3. Closes PRs where all checks have passed, reports pending/failed ones
+
+## URL Replacements
+
+In `eng/common/tools.sh`:
+```
+https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.sh
+→ https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.sh
 ```
 
-In `eng/common/tools.ps1`, find the URI assignment line:
-```powershell
-# Find (the URI assignment line — contains this literal text):
-$uri = "https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.ps1"
-
-# Replace the entire line with:
-$uri = "https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.ps1"
+In `eng/common/tools.ps1`:
 ```
-
-**Implementation using `gh` CLI and Git Data API:**
-
-For each repo, execute the following logic. **Stop and report an error** if any step fails.
-
-**Important: Preserving file content exactly.** Shell command substitution `$(...)` strips trailing newlines, and `printf '%s'` omits them. To avoid spurious whitespace diffs, use **base64 encoding** to round-trip file content through the Git Data API. Decode from the API response, perform the sed replacement on the decoded bytes written to a temp file, then re-encode to base64 for the blob creation. This preserves trailing newlines and avoids any shell-induced whitespace changes.
-
-**Important: Fork fallback for repos without push access.** Before creating a branch, check if the user has push access with `gh api "repos/${REPO}" --jq '.permissions.push'`. If `false`, fork the repo first with `gh repo fork "${REPO}" --clone=false`, then create the branch and commits in the user's fork. When opening the PR, use `--head "<username>:${BRANCH}"` to create a cross-fork PR.
-
-```bash
-REPO="dotnet/<repo_name>"
-COMMIT_SHA="<full_commit_sha>"
-SHORT_SHA="${COMMIT_SHA:0:8}"
-BRANCH="validate-install-scripts/${SHORT_SHA}"
-
-# Get default branch
-DEFAULT_BRANCH=$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
-
-# --- Determine where to push: upstream or fork ---
-HAS_PUSH=$(gh api "repos/${REPO}" --jq '.permissions.push')
-if [ "$HAS_PUSH" = "true" ]; then
-  TARGET_REPO="$REPO"
-  PR_HEAD="$BRANCH"
-else
-  # Fork the repo (idempotent — returns existing fork if already forked)
-  gh repo fork "$REPO" --clone=false
-  GH_USER=$(gh api user --jq '.login')
-  TARGET_REPO="${GH_USER}/$(basename $REPO)"
-  PR_HEAD="${GH_USER}:${BRANCH}"
-  # Sync fork's default branch with upstream
-  gh repo sync "$TARGET_REPO" --branch "$DEFAULT_BRANCH"
-fi
-
-# Check if branch already exists
-if gh api "repos/${TARGET_REPO}/git/ref/heads/${BRANCH}" &>/dev/null; then
-  echo "Branch ${BRANCH} already exists in ${TARGET_REPO}."
-  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$PR_HEAD" --state open --json url --jq '.[0].url')
-  if [ -n "$EXISTING_PR" ]; then
-    echo "PR already exists: $EXISTING_PR"
-    # Skip this repo and move to next
-    continue
-  fi
-fi
-
-# Get the HEAD SHA of the default branch
-BASE_SHA=$(gh api "repos/${TARGET_REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
-
-# Create the branch
-gh api "repos/${TARGET_REPO}/git/refs" \
-  -f "ref=refs/heads/${BRANCH}" \
-  -f "sha=${BASE_SHA}"
-
-# --- Fetch file content using base64 to preserve exact bytes ---
-# Write raw bytes to temp files to avoid shell newline stripping
-TMPDIR=$(mktemp -d)
-gh api "repos/${REPO}/contents/eng/common/tools.sh?ref=${DEFAULT_BRANCH}" --jq '.content' | base64 -d > "$TMPDIR/tools.sh"
-gh api "repos/${REPO}/contents/eng/common/tools.ps1?ref=${DEFAULT_BRANCH}" --jq '.content' | base64 -d > "$TMPDIR/tools.ps1"
-
-# --- Verify and replace in tools.sh ---
-MATCH_COUNT=$(grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh' "$TMPDIR/tools.sh" || true)
-if [ "$MATCH_COUNT" -ne 1 ]; then
-  echo "ERROR: Expected 1 match in tools.sh, found $MATCH_COUNT. The file format may have changed."
-  rm -rf "$TMPDIR"
-  exit 1
-fi
-
-sed -i 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.sh|' "$TMPDIR/tools.sh"
-
-# --- Verify and replace in tools.ps1 ---
-MATCH_COUNT=$(grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1' "$TMPDIR/tools.ps1" || true)
-if [ "$MATCH_COUNT" -ne 1 ]; then
-  echo "ERROR: Expected 1 match in tools.ps1, found $MATCH_COUNT. The file format may have changed."
-  rm -rf "$TMPDIR"
-  exit 1
-fi
-
-sed -i 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.ps1|' "$TMPDIR/tools.ps1"
-
-# --- Create blobs using base64 encoding to preserve exact bytes ---
-SH_BLOB=$(base64 -w 0 "$TMPDIR/tools.sh" | gh api "repos/${TARGET_REPO}/git/blobs" \
-  --method POST \
-  -f "encoding=base64" \
-  -F "content=@-" \
-  --jq '.sha')
-
-PS1_BLOB=$(base64 -w 0 "$TMPDIR/tools.ps1" | gh api "repos/${TARGET_REPO}/git/blobs" \
-  --method POST \
-  -f "encoding=base64" \
-  -F "content=@-" \
-  --jq '.sha')
-
-rm -rf "$TMPDIR"
-
-# --- Create tree and commit atomically ---
-BASE_TREE=$(gh api "repos/${TARGET_REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
-
-NEW_TREE=$(cat <<EOF | gh api "repos/${TARGET_REPO}/git/trees" --method POST --input - --jq '.sha'
-{
-  "base_tree": "${BASE_TREE}",
-  "tree": [
-    {"path": "eng/common/tools.sh", "mode": "100755", "type": "blob", "sha": "${SH_BLOB}"},
-    {"path": "eng/common/tools.ps1", "mode": "100644", "type": "blob", "sha": "${PS1_BLOB}"}
-  ]
-}
-EOF
-)
-
-NEW_COMMIT=$(cat <<EOF | gh api "repos/${TARGET_REPO}/git/commits" --method POST --input - --jq '.sha'
-{
-  "message": "Validate install scripts from dotnet/install-scripts@${SHORT_SHA}",
-  "tree": "${NEW_TREE}",
-  "parents": ["${BASE_SHA}"]
-}
-EOF
-)
-
-# Update the branch ref
-gh api "repos/${TARGET_REPO}/git/refs/heads/${BRANCH}" \
-  --method PATCH \
-  -f "sha=${NEW_COMMIT}"
-
-# Open a draft PR
-gh pr create --repo "$REPO" \
-  --base "$DEFAULT_BRANCH" \
-  --head "$PR_HEAD" \
-  --title "[DO NOT MERGE] Install Scripts Update Validation PR" \
-  --draft \
-  --body "This PR validates install script changes from dotnet/install-scripts commit \`${COMMIT_SHA}\`.
-
-**Do not merge this PR.** It will be closed once CI passes.
-
-Install scripts commit: https://github.com/dotnet/install-scripts/commit/${COMMIT_SHA}
-
-Changes:
-- \`eng/common/tools.sh\`: Points to test install script
-- \`eng/common/tools.ps1\`: Points to test install script"
+https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.ps1
+→ https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.ps1
 ```
-
-### Mode 2: Check CI Status and Close PRs
-
-**When to use:** After validation PRs have been opened and you want to check if CI has passed.
-
-**Input required:** The same commit SHA used when opening the PRs (to identify the correct branches/PRs).
-
-**Steps:**
-
-1. Ask the user for the commit SHA that was used to open the validation PRs.
-
-2. For each target repo, find the PR by branch name (check both direct and fork-based PRs):
-
-```bash
-SHORT_SHA="${COMMIT_SHA:0:8}"
-BRANCH="validate-install-scripts/${SHORT_SHA}"
-GH_USER=$(gh api user --jq '.login')
-
-for REPO in dotnet/aspnetcore dotnet/arcade dotnet/sdk dotnet/runtime dotnet/winforms; do
-  # Search for PR from direct branch or from user's fork
-  PR_INFO=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number,url,statusCheckRollup)
-  if [ -z "$PR_INFO" ] || [ "$PR_INFO" = "[]" ]; then
-    PR_INFO=$(gh pr list --repo "$REPO" --head "${GH_USER}:${BRANCH}" --state open --json number,url,statusCheckRollup)
-  fi
-  # Process results...
-done
-```
-
-3. For each PR found, check the CI status:
-
-```bash
-gh pr checks --repo "$REPO" <PR_NUMBER>
-```
-
-4. Report a summary table to the user showing each repo's status:
-   - ✅ All checks passed → offer to close
-   - ⏳ Checks still running → report pending
-   - ❌ Checks failed → report failures and let user decide
-
-5. For PRs where all **required** checks have passed, close them and delete the branch:
-
-```bash
-gh pr close --repo "$REPO" <PR_NUMBER> --delete-branch --comment "CI passed. Closing validation PR."
-```
-
-6. If some PRs are still pending, tell the user they can re-invoke this skill later.
-
-## Error Handling
-
-- **Commit not found:** If the commit SHA doesn't exist in `dotnet/install-scripts`, stop immediately and tell the user.
-- **No push access:** If the user lacks push access to a repo, fork it and create the branch in the fork. Open a cross-fork PR using `--head "<username>:<branch>"`. This is automatic — do not ask the user.
-- **Branch already exists:** If the branch exists and has an open PR, report the existing PR URL. If the branch exists but has no PR, offer to open one or delete and recreate.
-- **Replacement not found:** If the expected URL pattern is not found in `tools.sh` or `tools.ps1`, stop and report that the file format may have changed. Do not open a PR with unchanged files.
-- **Fork already exists:** `gh repo fork` is idempotent — if the fork already exists it returns successfully. No special handling needed.
 
 ## Notes
 
-- The `eng/common/` directory in these repos is managed by Arcade. The validation PRs intentionally modify these files temporarily — the changes are never merged.
-- PRs are opened as **drafts** to prevent accidental merge. Combined with the `[DO NOT MERGE]` title prefix, this provides two layers of protection.
-- The Git Data API approach creates a single atomic commit with both file changes, avoiding partial updates.
-- File content is round-tripped through **base64 encoding** (decode from API → write to temp file → sed in-place → re-encode for blob creation) to preserve exact bytes including trailing newlines and line endings.
-- If the user lacks push access to a target repo, the skill automatically forks the repo and creates a cross-fork PR. This makes the skill usable by anyone with a GitHub account.
-- CI run times vary by repo: Arcade is fastest (~30 min), Runtime can take several hours.
-- The branch name `validate-install-scripts/<short-sha>` serves as the correlation key between open and check-close modes.
+- PRs are opened as **drafts** with `[DO NOT MERGE]` title to prevent accidental merge.
+- File content is round-tripped through base64 to preserve exact bytes (no trailing whitespace changes).
+- The branch name `validate-install-scripts/<short-sha>` correlates open and check-close modes.
+- CI run times vary: Arcade ~30 min, Runtime can take several hours.
+

--- a/.github/skills/validate-install-scripts/SKILL.md
+++ b/.github/skills/validate-install-scripts/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: validate-install-scripts
+description: >
+  Open validation PRs in key .NET repos to test install script changes against their CI.
+  Use this skill when asked to validate install scripts, open validation PRs, or check/close
+  validation PRs. Supports two modes: 'open' (create PRs) and 'check-close' (verify CI and close).
+---
+
+# Validate Install Scripts in Key Repos
+
+This skill automates the "Validation in Key Repos" step of the install scripts release process.
+It opens PRs titled `[DO NOT MERGE] Install Scripts Update Validation PR` in key .NET repos
+that replace the production install script URL with a raw GitHub URL pointing to a specific commit.
+
+## Prerequisites
+
+- The `gh` CLI must be authenticated with permissions to create branches and PRs in the target repos.
+- The commit SHA must exist in the `dotnet/install-scripts` repository on GitHub.
+
+## Modes
+
+### Mode 1: Open Validation PRs
+
+**When to use:** After pushing install script changes that need validation across repos.
+
+**Input required:** A commit SHA from `dotnet/install-scripts` to validate.
+
+**Steps:**
+
+1. Ask the user for the commit SHA to validate (or accept it as input).
+
+2. Verify the commit exists on GitHub:
+```bash
+gh api "repos/dotnet/install-scripts/commits/<COMMIT_SHA>" --jq '.sha'
+```
+
+3. For each target repository, use `gh` CLI to:
+   a. Check if a branch/PR already exists for this SHA (handle idempotency)
+   b. Create a new branch named `validate-install-scripts/<short-sha>`
+   c. Modify both `eng/common/tools.sh` and `eng/common/tools.ps1` in a single commit
+   d. Open a PR with title `[DO NOT MERGE] Install Scripts Update Validation PR`
+
+4. Report all opened PR URLs to the user.
+
+**Target repositories:**
+- `dotnet/aspnetcore`
+- `dotnet/arcade`
+- `dotnet/sdk`
+- `dotnet/runtime`
+- `dotnet/winforms`
+
+**URL replacements:**
+
+In `eng/common/tools.sh`, find the line containing the install script URL assignment:
+```bash
+# Find (the URL assignment line — contains this literal text):
+local install_script_url="https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.sh"
+
+# Replace the entire line with:
+local install_script_url="https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.sh"
+```
+
+In `eng/common/tools.ps1`, find the URI assignment line:
+```powershell
+# Find (the URI assignment line — contains this literal text):
+$uri = "https://builds.dotnet.microsoft.com/dotnet/scripts/$dotnetInstallScriptVersion/dotnet-install.ps1"
+
+# Replace the entire line with:
+$uri = "https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/src/dotnet-install.ps1"
+```
+
+**Implementation using `gh` CLI and Git Data API:**
+
+For each repo, execute the following logic. **Stop and report an error** if any step fails.
+
+```bash
+REPO="dotnet/<repo_name>"
+COMMIT_SHA="<full_commit_sha>"
+SHORT_SHA="${COMMIT_SHA:0:8}"
+BRANCH="validate-install-scripts/${SHORT_SHA}"
+
+# Get default branch
+DEFAULT_BRANCH=$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+# Check if branch already exists
+if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" &>/dev/null; then
+  echo "Branch ${BRANCH} already exists in ${REPO}."
+  # Check if PR already exists
+  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json url --jq '.[0].url')
+  if [ -n "$EXISTING_PR" ]; then
+    echo "PR already exists: $EXISTING_PR"
+    # Skip this repo and move to next
+    continue
+  fi
+fi
+
+# Get the HEAD SHA of the default branch
+BASE_SHA=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+
+# Create the branch
+gh api "repos/${REPO}/git/refs" \
+  -f "ref=refs/heads/${BRANCH}" \
+  -f "sha=${BASE_SHA}"
+
+# --- Fetch and modify tools.sh ---
+TOOLS_SH_RESPONSE=$(gh api "repos/${REPO}/contents/eng/common/tools.sh?ref=${BRANCH}")
+TOOLS_SH_BLOB_SHA=$(echo "$TOOLS_SH_RESPONSE" | jq -r '.sha')
+TOOLS_SH_CONTENT=$(echo "$TOOLS_SH_RESPONSE" | jq -r '.content' | base64 -d)
+
+# Perform the replacement and verify exactly 1 match
+MATCH_COUNT=$(echo "$TOOLS_SH_CONTENT" | grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh' || true)
+if [ "$MATCH_COUNT" -ne 1 ]; then
+  echo "ERROR: Expected 1 match in tools.sh, found $MATCH_COUNT. The file format may have changed."
+  exit 1
+fi
+
+UPDATED_SH=$(printf '%s' "$TOOLS_SH_CONTENT" | sed 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.sh|')
+
+# --- Fetch and modify tools.ps1 ---
+TOOLS_PS1_RESPONSE=$(gh api "repos/${REPO}/contents/eng/common/tools.ps1?ref=${BRANCH}")
+TOOLS_PS1_BLOB_SHA=$(echo "$TOOLS_PS1_RESPONSE" | jq -r '.sha')
+TOOLS_PS1_CONTENT=$(echo "$TOOLS_PS1_RESPONSE" | jq -r '.content' | base64 -d)
+
+MATCH_COUNT=$(echo "$TOOLS_PS1_CONTENT" | grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1' || true)
+if [ "$MATCH_COUNT" -ne 1 ]; then
+  echo "ERROR: Expected 1 match in tools.ps1, found $MATCH_COUNT. The file format may have changed."
+  exit 1
+fi
+
+UPDATED_PS1=$(printf '%s' "$TOOLS_PS1_CONTENT" | sed 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.ps1|')
+
+# --- Create blobs, tree, and commit atomically via Git Data API ---
+# Create blob for tools.sh
+SH_BLOB=$(printf '%s' "$UPDATED_SH" | gh api "repos/${REPO}/git/blobs" \
+  --method POST \
+  -f "encoding=utf-8" \
+  -F "content=@-" \
+  --jq '.sha')
+
+# Create blob for tools.ps1
+PS1_BLOB=$(printf '%s' "$UPDATED_PS1" | gh api "repos/${REPO}/git/blobs" \
+  --method POST \
+  -f "encoding=utf-8" \
+  -F "content=@-" \
+  --jq '.sha')
+
+# Get the base tree
+BASE_TREE=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
+
+# Create a new tree with both file changes
+NEW_TREE=$(gh api "repos/${REPO}/git/trees" \
+  --method POST \
+  -f "base_tree=${BASE_TREE}" \
+  -f "tree[][path]=eng/common/tools.sh" \
+  -f "tree[][mode]=100755" \
+  -f "tree[][type]=blob" \
+  -f "tree[][sha]=${SH_BLOB}" \
+  -f "tree[][path]=eng/common/tools.ps1" \
+  -f "tree[][mode]=100644" \
+  -f "tree[][type]=blob" \
+  -f "tree[][sha]=${PS1_BLOB}" \
+  --jq '.sha')
+
+# Create the commit
+NEW_COMMIT=$(gh api "repos/${REPO}/git/commits" \
+  --method POST \
+  -f "message=Validate install scripts from dotnet/install-scripts@${SHORT_SHA}" \
+  -f "tree=${NEW_TREE}" \
+  -f "parents[]=${BASE_SHA}" \
+  --jq '.sha')
+
+# Update the branch ref to point to the new commit
+gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+  --method PATCH \
+  -f "sha=${NEW_COMMIT}"
+
+# Open the PR
+gh pr create --repo "$REPO" \
+  --base "$DEFAULT_BRANCH" \
+  --head "$BRANCH" \
+  --title "[DO NOT MERGE] Install Scripts Update Validation PR" \
+  --body "This PR validates install script changes from dotnet/install-scripts commit \`${COMMIT_SHA}\`.
+
+**Do not merge this PR.** It will be closed once CI passes.
+
+Install scripts commit: https://github.com/dotnet/install-scripts/commit/${COMMIT_SHA}
+
+Changes:
+- \`eng/common/tools.sh\`: Points to test install script
+- \`eng/common/tools.ps1\`: Points to test install script"
+```
+
+**Important:** The `tree[]` array syntax above is illustrative. When using `gh api`, you may need to construct the JSON body directly:
+
+```bash
+NEW_TREE=$(gh api "repos/${REPO}/git/trees" \
+  --method POST \
+  --input - <<EOF | jq -r '.sha'
+{
+  "base_tree": "${BASE_TREE}",
+  "tree": [
+    {"path": "eng/common/tools.sh", "mode": "100755", "type": "blob", "sha": "${SH_BLOB}"},
+    {"path": "eng/common/tools.ps1", "mode": "100644", "type": "blob", "sha": "${PS1_BLOB}"}
+  ]
+}
+EOF
+)
+```
+
+### Mode 2: Check CI Status and Close PRs
+
+**When to use:** After validation PRs have been opened and you want to check if CI has passed.
+
+**Input required:** The same commit SHA used when opening the PRs (to identify the correct branches/PRs).
+
+**Steps:**
+
+1. Ask the user for the commit SHA that was used to open the validation PRs.
+
+2. For each target repo, find the PR by branch name:
+
+```bash
+SHORT_SHA="${COMMIT_SHA:0:8}"
+BRANCH="validate-install-scripts/${SHORT_SHA}"
+
+for REPO in dotnet/aspnetcore dotnet/arcade dotnet/sdk dotnet/runtime dotnet/winforms; do
+  PR_INFO=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number,url,statusCheckRollup)
+  # Process results...
+done
+```
+
+3. For each PR found, check the CI status:
+
+```bash
+gh pr checks --repo "$REPO" <PR_NUMBER>
+```
+
+4. Report a summary table to the user showing each repo's status:
+   - ✅ All checks passed → offer to close
+   - ⏳ Checks still running → report pending
+   - ❌ Checks failed → report failures and let user decide
+
+5. For PRs where all **required** checks have passed, close them and delete the branch:
+
+```bash
+gh pr close --repo "$REPO" <PR_NUMBER> --delete-branch --comment "CI passed. Closing validation PR."
+```
+
+6. If some PRs are still pending, tell the user they can re-invoke this skill later.
+
+## Error Handling
+
+- **Commit not found:** If the commit SHA doesn't exist in `dotnet/install-scripts`, stop immediately and tell the user.
+- **Permission denied:** If `gh` cannot create branches/PRs in a repo, report which repo failed and continue with the others.
+- **Branch already exists:** If the branch exists and has an open PR, report the existing PR URL. If the branch exists but has no PR, offer to open one or delete and recreate.
+- **Replacement not found:** If the expected URL pattern is not found in `tools.sh` or `tools.ps1`, stop and report that the file format may have changed. Do not open a PR with unchanged files.
+
+## Notes
+
+- The `eng/common/` directory in these repos is managed by Arcade. The validation PRs intentionally modify these files temporarily — the changes are never merged.
+- The Git Data API approach creates a single atomic commit with both file changes, avoiding partial updates.
+- CI run times vary by repo: Arcade is fastest (~30 min), Runtime can take several hours.
+- The branch name `validate-install-scripts/<short-sha>` serves as the correlation key between open and check-close modes.

--- a/.github/skills/validate-install-scripts/SKILL.md
+++ b/.github/skills/validate-install-scripts/SKILL.md
@@ -17,6 +17,26 @@ that replace the production install script URL with a raw GitHub URL pointing to
 - The `gh` CLI must be authenticated with permissions to create branches and PRs in the target repos.
 - The commit SHA must exist in the `dotnet/install-scripts` repository on GitHub.
 
+## Quick Start (Preferred)
+
+If PowerShell (Core or Windows PowerShell) is available, use the scripts directly:
+
+```powershell
+# Open validation PRs
+./.github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>"
+
+# Later, check CI and close passed PRs
+./.github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>"
+
+# To auto-close without prompting:
+./.github/skills/validate-install-scripts/Close-ValidationPRs.ps1 -CommitSha "<sha>" -AutoClose
+
+# To target specific repos only:
+./.github/skills/validate-install-scripts/Open-ValidationPRs.ps1 -CommitSha "<sha>" -Repos @("arcade", "sdk")
+```
+
+If PowerShell is not available, follow the manual steps below using the `gh` CLI directly.
+
 ## Modes
 
 ### Mode 1: Open Validation PRs

--- a/.github/skills/validate-install-scripts/SKILL.md
+++ b/.github/skills/validate-install-scripts/SKILL.md
@@ -73,6 +73,10 @@ $uri = "https://raw.githubusercontent.com/dotnet/install-scripts/<COMMIT_SHA>/sr
 
 For each repo, execute the following logic. **Stop and report an error** if any step fails.
 
+**Important: Preserving file content exactly.** Shell command substitution `$(...)` strips trailing newlines, and `printf '%s'` omits them. To avoid spurious whitespace diffs, use **base64 encoding** to round-trip file content through the Git Data API. Decode from the API response, perform the sed replacement on the decoded bytes written to a temp file, then re-encode to base64 for the blob creation. This preserves trailing newlines and avoids any shell-induced whitespace changes.
+
+**Important: Fork fallback for repos without push access.** Before creating a branch, check if the user has push access with `gh api "repos/${REPO}" --jq '.permissions.push'`. If `false`, fork the repo first with `gh repo fork "${REPO}" --clone=false`, then create the branch and commits in the user's fork. When opening the PR, use `--head "<username>:${BRANCH}"` to create a cross-fork PR.
+
 ```bash
 REPO="dotnet/<repo_name>"
 COMMIT_SHA="<full_commit_sha>"
@@ -82,11 +86,25 @@ BRANCH="validate-install-scripts/${SHORT_SHA}"
 # Get default branch
 DEFAULT_BRANCH=$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
 
+# --- Determine where to push: upstream or fork ---
+HAS_PUSH=$(gh api "repos/${REPO}" --jq '.permissions.push')
+if [ "$HAS_PUSH" = "true" ]; then
+  TARGET_REPO="$REPO"
+  PR_HEAD="$BRANCH"
+else
+  # Fork the repo (idempotent — returns existing fork if already forked)
+  gh repo fork "$REPO" --clone=false
+  GH_USER=$(gh api user --jq '.login')
+  TARGET_REPO="${GH_USER}/$(basename $REPO)"
+  PR_HEAD="${GH_USER}:${BRANCH}"
+  # Sync fork's default branch with upstream
+  gh repo sync "$TARGET_REPO" --branch "$DEFAULT_BRANCH"
+fi
+
 # Check if branch already exists
-if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" &>/dev/null; then
-  echo "Branch ${BRANCH} already exists in ${REPO}."
-  # Check if PR already exists
-  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json url --jq '.[0].url')
+if gh api "repos/${TARGET_REPO}/git/ref/heads/${BRANCH}" &>/dev/null; then
+  echo "Branch ${BRANCH} already exists in ${TARGET_REPO}."
+  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$PR_HEAD" --state open --json url --jq '.[0].url')
   if [ -n "$EXISTING_PR" ]; then
     echo "PR already exists: $EXISTING_PR"
     # Skip this repo and move to next
@@ -95,107 +113,58 @@ if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" &>/dev/null; then
 fi
 
 # Get the HEAD SHA of the default branch
-BASE_SHA=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+BASE_SHA=$(gh api "repos/${TARGET_REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
 
 # Create the branch
-gh api "repos/${REPO}/git/refs" \
+gh api "repos/${TARGET_REPO}/git/refs" \
   -f "ref=refs/heads/${BRANCH}" \
   -f "sha=${BASE_SHA}"
 
-# --- Fetch and modify tools.sh ---
-TOOLS_SH_RESPONSE=$(gh api "repos/${REPO}/contents/eng/common/tools.sh?ref=${BRANCH}")
-TOOLS_SH_BLOB_SHA=$(echo "$TOOLS_SH_RESPONSE" | jq -r '.sha')
-TOOLS_SH_CONTENT=$(echo "$TOOLS_SH_RESPONSE" | jq -r '.content' | base64 -d)
+# --- Fetch file content using base64 to preserve exact bytes ---
+# Write raw bytes to temp files to avoid shell newline stripping
+TMPDIR=$(mktemp -d)
+gh api "repos/${REPO}/contents/eng/common/tools.sh?ref=${DEFAULT_BRANCH}" --jq '.content' | base64 -d > "$TMPDIR/tools.sh"
+gh api "repos/${REPO}/contents/eng/common/tools.ps1?ref=${DEFAULT_BRANCH}" --jq '.content' | base64 -d > "$TMPDIR/tools.ps1"
 
-# Perform the replacement and verify exactly 1 match
-MATCH_COUNT=$(echo "$TOOLS_SH_CONTENT" | grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh' || true)
+# --- Verify and replace in tools.sh ---
+MATCH_COUNT=$(grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh' "$TMPDIR/tools.sh" || true)
 if [ "$MATCH_COUNT" -ne 1 ]; then
   echo "ERROR: Expected 1 match in tools.sh, found $MATCH_COUNT. The file format may have changed."
+  rm -rf "$TMPDIR"
   exit 1
 fi
 
-UPDATED_SH=$(printf '%s' "$TOOLS_SH_CONTENT" | sed 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.sh|')
+sed -i 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.sh|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.sh|' "$TMPDIR/tools.sh"
 
-# --- Fetch and modify tools.ps1 ---
-TOOLS_PS1_RESPONSE=$(gh api "repos/${REPO}/contents/eng/common/tools.ps1?ref=${BRANCH}")
-TOOLS_PS1_BLOB_SHA=$(echo "$TOOLS_PS1_RESPONSE" | jq -r '.sha')
-TOOLS_PS1_CONTENT=$(echo "$TOOLS_PS1_RESPONSE" | jq -r '.content' | base64 -d)
-
-MATCH_COUNT=$(echo "$TOOLS_PS1_CONTENT" | grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1' || true)
+# --- Verify and replace in tools.ps1 ---
+MATCH_COUNT=$(grep -c 'builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1' "$TMPDIR/tools.ps1" || true)
 if [ "$MATCH_COUNT" -ne 1 ]; then
   echo "ERROR: Expected 1 match in tools.ps1, found $MATCH_COUNT. The file format may have changed."
+  rm -rf "$TMPDIR"
   exit 1
 fi
 
-UPDATED_PS1=$(printf '%s' "$TOOLS_PS1_CONTENT" | sed 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.ps1|')
+sed -i 's|https://builds.dotnet.microsoft.com/dotnet/scripts/\$dotnetInstallScriptVersion/dotnet-install.ps1|https://raw.githubusercontent.com/dotnet/install-scripts/'"${COMMIT_SHA}"'/src/dotnet-install.ps1|' "$TMPDIR/tools.ps1"
 
-# --- Create blobs, tree, and commit atomically via Git Data API ---
-# Create blob for tools.sh
-SH_BLOB=$(printf '%s' "$UPDATED_SH" | gh api "repos/${REPO}/git/blobs" \
+# --- Create blobs using base64 encoding to preserve exact bytes ---
+SH_BLOB=$(base64 -w 0 "$TMPDIR/tools.sh" | gh api "repos/${TARGET_REPO}/git/blobs" \
   --method POST \
-  -f "encoding=utf-8" \
+  -f "encoding=base64" \
   -F "content=@-" \
   --jq '.sha')
 
-# Create blob for tools.ps1
-PS1_BLOB=$(printf '%s' "$UPDATED_PS1" | gh api "repos/${REPO}/git/blobs" \
+PS1_BLOB=$(base64 -w 0 "$TMPDIR/tools.ps1" | gh api "repos/${TARGET_REPO}/git/blobs" \
   --method POST \
-  -f "encoding=utf-8" \
+  -f "encoding=base64" \
   -F "content=@-" \
   --jq '.sha')
 
-# Get the base tree
-BASE_TREE=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
+rm -rf "$TMPDIR"
 
-# Create a new tree with both file changes
-NEW_TREE=$(gh api "repos/${REPO}/git/trees" \
-  --method POST \
-  -f "base_tree=${BASE_TREE}" \
-  -f "tree[][path]=eng/common/tools.sh" \
-  -f "tree[][mode]=100755" \
-  -f "tree[][type]=blob" \
-  -f "tree[][sha]=${SH_BLOB}" \
-  -f "tree[][path]=eng/common/tools.ps1" \
-  -f "tree[][mode]=100644" \
-  -f "tree[][type]=blob" \
-  -f "tree[][sha]=${PS1_BLOB}" \
-  --jq '.sha')
+# --- Create tree and commit atomically ---
+BASE_TREE=$(gh api "repos/${TARGET_REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
 
-# Create the commit
-NEW_COMMIT=$(gh api "repos/${REPO}/git/commits" \
-  --method POST \
-  -f "message=Validate install scripts from dotnet/install-scripts@${SHORT_SHA}" \
-  -f "tree=${NEW_TREE}" \
-  -f "parents[]=${BASE_SHA}" \
-  --jq '.sha')
-
-# Update the branch ref to point to the new commit
-gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
-  --method PATCH \
-  -f "sha=${NEW_COMMIT}"
-
-# Open the PR
-gh pr create --repo "$REPO" \
-  --base "$DEFAULT_BRANCH" \
-  --head "$BRANCH" \
-  --title "[DO NOT MERGE] Install Scripts Update Validation PR" \
-  --body "This PR validates install script changes from dotnet/install-scripts commit \`${COMMIT_SHA}\`.
-
-**Do not merge this PR.** It will be closed once CI passes.
-
-Install scripts commit: https://github.com/dotnet/install-scripts/commit/${COMMIT_SHA}
-
-Changes:
-- \`eng/common/tools.sh\`: Points to test install script
-- \`eng/common/tools.ps1\`: Points to test install script"
-```
-
-**Important:** The `tree[]` array syntax above is illustrative. When using `gh api`, you may need to construct the JSON body directly:
-
-```bash
-NEW_TREE=$(gh api "repos/${REPO}/git/trees" \
-  --method POST \
-  --input - <<EOF | jq -r '.sha'
+NEW_TREE=$(cat <<EOF | gh api "repos/${TARGET_REPO}/git/trees" --method POST --input - --jq '.sha'
 {
   "base_tree": "${BASE_TREE}",
   "tree": [
@@ -205,6 +174,36 @@ NEW_TREE=$(gh api "repos/${REPO}/git/trees" \
 }
 EOF
 )
+
+NEW_COMMIT=$(cat <<EOF | gh api "repos/${TARGET_REPO}/git/commits" --method POST --input - --jq '.sha'
+{
+  "message": "Validate install scripts from dotnet/install-scripts@${SHORT_SHA}",
+  "tree": "${NEW_TREE}",
+  "parents": ["${BASE_SHA}"]
+}
+EOF
+)
+
+# Update the branch ref
+gh api "repos/${TARGET_REPO}/git/refs/heads/${BRANCH}" \
+  --method PATCH \
+  -f "sha=${NEW_COMMIT}"
+
+# Open a draft PR
+gh pr create --repo "$REPO" \
+  --base "$DEFAULT_BRANCH" \
+  --head "$PR_HEAD" \
+  --title "[DO NOT MERGE] Install Scripts Update Validation PR" \
+  --draft \
+  --body "This PR validates install script changes from dotnet/install-scripts commit \`${COMMIT_SHA}\`.
+
+**Do not merge this PR.** It will be closed once CI passes.
+
+Install scripts commit: https://github.com/dotnet/install-scripts/commit/${COMMIT_SHA}
+
+Changes:
+- \`eng/common/tools.sh\`: Points to test install script
+- \`eng/common/tools.ps1\`: Points to test install script"
 ```
 
 ### Mode 2: Check CI Status and Close PRs
@@ -217,14 +216,19 @@ EOF
 
 1. Ask the user for the commit SHA that was used to open the validation PRs.
 
-2. For each target repo, find the PR by branch name:
+2. For each target repo, find the PR by branch name (check both direct and fork-based PRs):
 
 ```bash
 SHORT_SHA="${COMMIT_SHA:0:8}"
 BRANCH="validate-install-scripts/${SHORT_SHA}"
+GH_USER=$(gh api user --jq '.login')
 
 for REPO in dotnet/aspnetcore dotnet/arcade dotnet/sdk dotnet/runtime dotnet/winforms; do
+  # Search for PR from direct branch or from user's fork
   PR_INFO=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number,url,statusCheckRollup)
+  if [ -z "$PR_INFO" ] || [ "$PR_INFO" = "[]" ]; then
+    PR_INFO=$(gh pr list --repo "$REPO" --head "${GH_USER}:${BRANCH}" --state open --json number,url,statusCheckRollup)
+  fi
   # Process results...
 done
 ```
@@ -251,13 +255,17 @@ gh pr close --repo "$REPO" <PR_NUMBER> --delete-branch --comment "CI passed. Clo
 ## Error Handling
 
 - **Commit not found:** If the commit SHA doesn't exist in `dotnet/install-scripts`, stop immediately and tell the user.
-- **Permission denied:** If `gh` cannot create branches/PRs in a repo, report which repo failed and continue with the others.
+- **No push access:** If the user lacks push access to a repo, fork it and create the branch in the fork. Open a cross-fork PR using `--head "<username>:<branch>"`. This is automatic — do not ask the user.
 - **Branch already exists:** If the branch exists and has an open PR, report the existing PR URL. If the branch exists but has no PR, offer to open one or delete and recreate.
 - **Replacement not found:** If the expected URL pattern is not found in `tools.sh` or `tools.ps1`, stop and report that the file format may have changed. Do not open a PR with unchanged files.
+- **Fork already exists:** `gh repo fork` is idempotent — if the fork already exists it returns successfully. No special handling needed.
 
 ## Notes
 
 - The `eng/common/` directory in these repos is managed by Arcade. The validation PRs intentionally modify these files temporarily — the changes are never merged.
+- PRs are opened as **drafts** to prevent accidental merge. Combined with the `[DO NOT MERGE]` title prefix, this provides two layers of protection.
 - The Git Data API approach creates a single atomic commit with both file changes, avoiding partial updates.
+- File content is round-tripped through **base64 encoding** (decode from API → write to temp file → sed in-place → re-encode for blob creation) to preserve exact bytes including trailing newlines and line endings.
+- If the user lacks push access to a target repo, the skill automatically forks the repo and creates a cross-fork PR. This makes the skill usable by anyone with a GitHub account.
 - CI run times vary by repo: Arcade is fastest (~30 min), Runtime can take several hours.
 - The branch name `validate-install-scripts/<short-sha>` serves as the correlation key between open and check-close modes.


### PR DESCRIPTION
## Summary

Adds a Copilot CLI skill to automate the "Validation in Key Repos" step of the install scripts release process.

### What it does

- **Open mode**: Opens draft PRs in target repos (arcade, aspnetcore, sdk, runtime, winforms) that swap production install script URLs with raw GitHub URLs pointing to a test commit.
- **Check/Close mode**: Checks CI status on all validation PRs and closes those that pass.

### Files

- `.github/skills/validate-install-scripts/SKILL.md` — Skill definition
- `.github/skills/validate-install-scripts/Open-ValidationPRs.ps1` — Opens draft validation PRs
- `.github/skills/validate-install-scripts/Close-ValidationPRs.ps1` — Checks CI and closes passing PRs

### Design choices

- PowerShell Core scripts for cross-platform support (Windows + Linux/macOS)
- Fork fallback: if user lacks push access to a target repo, automatically uses their fork
- Draft PRs to prevent accidental merge
- Git Data API for atomic commits (both files in a single commit)
- CANCELLED checks separated from FAILURE (cancelled jobs are ambiguous)