### PR TITLE
Replace PublishBuildArtifacts@1 with 1ES-compliant template

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -87,12 +87,12 @@ extends:
                 testRunTitle: $(Agent.JobName)
                 mergeTestResults: true
               condition: always()
-            - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
-              parameters:
-                displayName: Publish Logs
-                pathToPublish: artifacts/log
-                artifactName: Logs_$(Agent.JobName)
-                condition: always()
+            - task: 1ES.PublishBuildArtifacts@1
+              displayName: Publish Logs
+              inputs:
+                PathtoPublish: artifacts/log
+                ArtifactName: Logs_$(Agent.JobName)
+              condition: always()
             - script: eng\common\cibuild.cmd
                 -configuration Release
                 -projects src/Signing/SignScripts.csproj
@@ -131,12 +131,12 @@ extends:
             testRunTitle: $(Agent.JobName)
             mergeTestResults: true
           condition: always()
-        - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
-          parameters:
-            displayName: Publish Logs
-            pathToPublish: artifacts/log
-            artifactName: Logs_$(Agent.JobName)
-            condition: always()
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: Publish Logs
+          inputs:
+            PathtoPublish: artifacts/log
+            ArtifactName: Logs_$(Agent.JobName)
+          condition: always()
 
       - job: MacOS
         timeoutInMinutes: 45
@@ -158,12 +158,12 @@ extends:
             testRunTitle: $(Agent.JobName)
             mergeTestResults: true
           condition: always()
-        - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
-          parameters:
-            displayName: Publish Logs
-            pathToPublish: artifacts/log
-            artifactName: Logs_$(Agent.JobName)
-            condition: always()
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: Publish Logs
+          inputs:
+            PathtoPublish: artifacts/log
+            ArtifactName: Logs_$(Agent.JobName)
+          condition: always()
 
     - template: eng\common\templates-official\post-build\post-build.yml@self
       parameters:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -87,12 +87,12 @@ extends:
                 testRunTitle: $(Agent.JobName)
                 mergeTestResults: true
               condition: always()
-            - task: PublishBuildArtifacts@1
-              displayName: Publish Logs
-              inputs:
-                PathtoPublish: artifacts/log
-                ArtifactName: Logs_$(Agent.JobName)
-              condition: always()
+            - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
+              parameters:
+                displayName: Publish Logs
+                pathToPublish: artifacts/log
+                artifactName: Logs_$(Agent.JobName)
+                condition: always()
             - script: eng\common\cibuild.cmd
                 -configuration Release
                 -projects src/Signing/SignScripts.csproj
@@ -131,12 +131,12 @@ extends:
             testRunTitle: $(Agent.JobName)
             mergeTestResults: true
           condition: always()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs
-          inputs:
-            PathtoPublish: artifacts/log
-            ArtifactName: Logs_$(Agent.JobName)
-          condition: always()
+        - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
+          parameters:
+            displayName: Publish Logs
+            pathToPublish: artifacts/log
+            artifactName: Logs_$(Agent.JobName)
+            condition: always()
 
       - job: MacOS
         timeoutInMinutes: 45
@@ -158,12 +158,12 @@ extends:
             testRunTitle: $(Agent.JobName)
             mergeTestResults: true
           condition: always()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs
-          inputs:
-            PathtoPublish: artifacts/log
-            ArtifactName: Logs_$(Agent.JobName)
-          condition: always()
+        - template: /eng/common/templates-official/steps/publish-build-artifacts.yml@self
+          parameters:
+            displayName: Publish Logs
+            pathToPublish: artifacts/log
+            artifactName: Logs_$(Agent.JobName)
+            condition: always()
 
     - template: eng\common\templates-official\post-build\post-build.yml@self
       parameters:


### PR DESCRIPTION
## Fix

Replaces all three `PublishBuildArtifacts@1` task usages in `azure-pipelines-official.yml` with the Arcade-provided `eng/common/templates-official/steps/publish-build-artifacts.yml` template, which uses the 1ES-approved `1ES.PublishBuildArtifacts@1` task.

## Context

The 1ES Pipeline Templates now reject `PublishBuildArtifacts@1` with:
```
PublishBuildArtifacts@1 task is not allowed. Please use `output: pipelineArtifact` instead.
```

This broke the [official pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=847).

[Test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2967831)

Fixes #712