### PR TITLE
Fix hash mismatch on signed dotnet-install.ps1 (non-ASCII characters)

### DIFF
--- a/src/dotnet-install.ps1
+++ b/src/dotnet-install.ps1
@@ -939,7 +939,7 @@ function Extract-Dotnet-Package-Tar([string]$TarPath, [string]$OutPath) {
 
     foreach ($dir in $versionedDirs.GetEnumerator()) {
         if ($dir.Value) {
-            # This versioned directory already exists — exclude it from extraction
+            # This versioned directory already exists - exclude it from extraction
             $pattern = $dir.Key + '*'
             $excludeArgs += '--exclude'
             $excludeArgs += $pattern
@@ -956,7 +956,7 @@ function Extract-Dotnet-Package-Tar([string]$TarPath, [string]$OutPath) {
             if ($normalizedEntry.EndsWith('/')) { continue }
             $match = [regex]::Match($normalizedEntry, $versionRegex)
             if (-not $match.Success) {
-                # Non-versioned file — exclude if it already exists locally
+                # Non-versioned file - exclude if it already exists locally
                 $localPath = Join-Path -Path $OutPath -ChildPath $normalizedEntry
                 if (Test-Path $localPath) {
                     $excludeArgs += '--exclude'

--- a/tests/Install-Scripts.Test/ScriptEncodingTests.cs
+++ b/tests/Install-Scripts.Test/ScriptEncodingTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.DotNet.InstallationScript.Tests
+{
+    /// <summary>
+    /// Guards against non-ASCII characters creeping into the install scripts.
+    ///
+    /// When a signed PowerShell script contains non-ASCII characters and is saved
+    /// without a byte-order mark, its Authenticode content hash fails validation on
+    /// machines whose active code page differs from the signing machine, producing:
+    /// "the hash of the file does not match the hash stored in the digital signature".
+    /// This has happened twice (issues #541 and #729), so this test fails the build
+    /// the moment any non-ASCII byte is introduced into either script.
+    /// See https://learn.microsoft.com/troubleshoot/windows-client/system-management-components/signed-powershell-script-fails-hash-mismatch
+    /// </summary>
+    public class ScriptEncodingTests
+    {
+        [Theory]
+        [InlineData("dotnet-install.ps1")]
+        [InlineData("dotnet-install.sh")]
+        public void Script_contains_only_ASCII_characters(string scriptFileName)
+        {
+            string scriptPath = Path.Combine(GetRepoRoot(), "src", scriptFileName);
+            Assert.True(File.Exists(scriptPath), $"Could not locate script at '{scriptPath}'.");
+
+            byte[] bytes = File.ReadAllBytes(scriptPath);
+
+            int line = 1;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                byte b = bytes[i];
+                if (b == (byte)'\n')
+                {
+                    line++;
+                    continue;
+                }
+
+                if (b > 127)
+                {
+                    string message =
+                        $"Non-ASCII byte 0x{b:X2} found in '{scriptFileName}' at line {line} (byte offset {i}). " +
+                        "Signed PowerShell scripts must contain only ASCII characters to avoid hash-mismatch " +
+                        "failures across locales (issues #541, #729). Replace it with an ASCII equivalent.";
+                    Assert.Fail(message);
+                }
+            }
+        }
+
+        private static string GetRepoRoot()
+        {
+            string? directory = AppContext.BaseDirectory;
+
+            // The repo root is the directory containing ".git". In a normal clone that is a
+            // directory; in a git worktree it is a file (a gitdir pointer), so check for both.
+            while (directory != null &&
+                   !Directory.Exists(Path.Combine(directory, ".git")) &&
+                   !File.Exists(Path.Combine(directory, ".git")))
+            {
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            Assert.True(directory != null, "Could not locate the repository root (no '.git' found).");
+            return directory!;
+        }
+    }
+}


### PR DESCRIPTION
## Why

Users running the signed `dotnet-install.ps1` (from https://dot.net/v1/dotnet-install.ps1) under the `AllSigned` execution policy hit:

> the hash of the file does not match the hash stored in the digital signature

This is a recurrence of #541 (previously fixed in #543 by removing an emoji).

## Root cause

`src/dotnet-install.ps1` contained two non-ASCII em dash characters (`U+2014`) in code comments on lines 942 and 959, introduced in #697. The file is saved without a byte-order mark, and when a script containing non-ASCII characters is Authenticode-signed without a BOM, its content hash fails validation on machines whose active code page differs from the signing machine. See the [Microsoft troubleshooting guide](https://learn.microsoft.com/troubleshoot/windows-client/system-management-components/signed-powershell-script-fails-hash-mismatch). The `.sh` script was unaffected.

## Approach

- Replaced both em dashes with plain ASCII hyphens. Comments only, so there is no runtime behavior change. Verified the file has zero non-ASCII bytes, no BOM was introduced, and CRLF line endings are preserved.
- Added a cross-platform regression test (`ScriptEncodingTests`) that reads both install scripts as bytes and fails with the exact line and offset if any byte is greater than 127. Since this bug class has now shipped twice, the test guards against a third recurrence.

## Validation

- The new test passes against both scripts after the fix.
- Confirmed the guard actually works by temporarily injecting a non-ASCII byte (the test failed as expected), then reverting.

I chose to remove the characters rather than add a UTF-8 BOM, matching the precedent from #543.

Fixes: #729