### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -28,7 +28,6 @@ variables:
       value: real
     - name: _UseBuildManifest
       value: False
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: DotNet-Install-Scripts-SDLValidation-Params
     - name: _InternalBuildArgs

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,7 +22,7 @@ jobs:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2017
     variables:
-    - group: Publish-Build-Assets
+    - group: DotNet-Maestro
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/common-variables.yml`
- `eng/validate-sdk.yml`

The validation job still consumes `BotAccount-dotnet-maestro-bot-PAT`, so its import is narrowed to `DotNet-Maestro` rather than removed.

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131